### PR TITLE
fix: Reference createBlob from globals

### DIFF
--- a/harper-best-practices/rules/handling-binary-data.md
+++ b/harper-best-practices/rules/handling-binary-data.md
@@ -13,11 +13,9 @@ Use this skill when you need to store binary files (images, audio, etc.) in the 
 
 ## How It Works
 
-1. **Store Binary Data**: In your resource's `post` or `put` method, convert incoming data to Buffers and then to Blobs using `createBlob`. Include the MIME type if available:
+1. **Store Binary Data**: In your resource's `post` or `put` method, convert incoming data to Buffers and then to Blobs using `createBlob` from Harper's globals. Include the MIME type if available:
 
    ```typescript
-   import { createBlob } from 'harperdb';
-
    async post(target, record) {
      if (record.data) {
        record.data = createBlob(Buffer.from(record.data, record.encoding || 'base64'), {

--- a/harper-best-practices/rules/using-blob-datatype.md
+++ b/harper-best-practices/rules/using-blob-datatype.md
@@ -20,9 +20,9 @@ Use this skill when you need to store unstructured or large binary data (media, 
    	data: Blob
    }
    ```
-2. **Create and Store Blobs**: Use `createBlob()` from `harperdb` to wrap Buffers or Streams:
+2. **Create and Store Blobs**: Use `createBlob()` from Harper's globals to wrap Buffers or Streams:
    ```javascript
-   import { createBlob, tables } from 'harperdb';
+   import { tables } from 'harperdb';
    const blob = createBlob(largeBuffer);
    await tables.MyTable.put('my-id', { data: blob });
    ```


### PR DESCRIPTION
It isn’t exported at the moment.