### PR TITLE
docs: update harperdb references to harper for v5

### DIFF
--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -48,7 +48,7 @@ Use this skill when you need to define new data structures or modify existing on
 #### How It Works
 
 1. **Create Dedicated Schema Files**: Prefer having a dedicated schema `.graphql` file for each table. Check the `config.yaml` file under `graphqlSchema.files` to see how it's configured. It typically accepts wildcards (e.g., `schemas/*.graphql`), but may be configured to point at a single file.
-2. **Use Directives**: All available directives for defining your schema are defined in `node_modules/harperdb/schema.graphql`. Common directives include `@table`, `@export`, `@primaryKey`, `@indexed`, and `@relationship`.
+2. **Use Directives**: All available directives for defining your schema are defined in `node_modules/harper/schema.graphql`. Common directives include `@table`, `@export`, `@primaryKey`, `@indexed`, and `@relationship`.
 3. **Define Relationships**: Link tables together using the `@relationship` directive.
 4. **Enable Automatic APIs**: If you add `@table @export` to a schema type, Harper automatically sets up REST and WebSocket APIs for basic CRUD operations against that table.
 5. **Consider Table Extensions**: If you are going to extend the table in your resources, then do not `@export` the table from the schema.
@@ -69,7 +69,7 @@ Harper uses GraphQL schemas to define database tables, relationships, and APIs. 
 
 #### Core Harper Directives
 
-Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harperdb/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
+Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harper/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
 
 ##### Table Definition
 
@@ -103,7 +103,7 @@ Create a file named `graphql.config.yml` in your project root with the following
 
 ```yaml
 schema:
-  - 'node_modules/harperdb/schema.graphql'
+  - 'node_modules/harper/schema.graphql'
   - 'schema.graphql'
   - 'schemas/*.graphql'
 ```
@@ -299,7 +299,7 @@ How to define custom REST endpoints using JavaScript or TypeScript.
 #### How It Works
 
 1. **Create Resource File**: Define your logic in a JS or TS file.
-2. **Define Resource Class**: Export a class extending `Resource` from `harperdb`.
+2. **Define Resource Class**: Export a class extending `Resource` from `harper`.
 3. **Implement HTTP Methods**: Add methods like `get`, `post`, `put`, `patch`, or `delete` to handle corresponding requests.
 4. **Route Nesting and Naming**: You can control the URL structure by how you export your resources:
    - **Direct Class Export**: `export class Foo extends Resource` creates endpoints at `/Foo/`. Class names are case-sensitive in the URL.
@@ -430,11 +430,11 @@ Add the following scripts and dependencies to your `package.json`:
 {
 	"scripts": {
 		"deploy": "dotenv -- npm run deploy:component",
-		"deploy:component": "harperdb deploy_component . restart=rolling replicated=true"
+		"deploy:component": "harper deploy_component . restart=rolling replicated=true"
 	},
 	"devDependencies": {
 		"dotenv-cli": "^11.0.0",
-		"harperdb": "^4.7.20"
+		"harper": "^5.0.0"
 	}
 }
 ```
@@ -446,7 +446,7 @@ The `deploy` script is separated from `deploy:component` to ensure environment v
 - `deploy`: Uses `dotenv-cli` to load environment variables (like `CLI_TARGET`, `CLI_TARGET_USERNAME`, and `CLI_TARGET_PASSWORD`) before executing the next command.
 - `deploy:component`: The actual command that performs the deployment.
 
-By using `dotenv -- npm run deploy:component`, the environment variables are correctly set in the shell session before `harperdb deploy_component` is called, allowing it to authenticate with your cluster.
+By using `dotenv -- npm run deploy:component`, the environment variables are correctly set in the shell session before `harper deploy_component` is called, allowing it to authenticate with your cluster.
 
 #### 2. Configure GitHub Actions
 
@@ -499,7 +499,7 @@ Two ways to serve web content from a Harper application.
 
 #### Methods
 
-1. **Static Serving**: Serve HTML, CSS, and JS files directly. If using the Vite plugin for development, ensure Harper is running (e.g., `harperdb run .`) to allow for Hot Module Replacement (HMR).
+1. **Static Serving**: Serve HTML, CSS, and JS files directly. If using the Vite plugin for development, ensure Harper is running (e.g., `harper run .`) to allow for Hot Module Replacement (HMR).
 2. **Dynamic Rendering**: Use custom resources to render content on the fly.
 
 ### 4.5 Logging Best Practices

--- a/harper-best-practices/rules/adding-tables-with-schemas.md
+++ b/harper-best-practices/rules/adding-tables-with-schemas.md
@@ -14,7 +14,7 @@ Use this skill when you need to define new data structures or modify existing on
 ## How It Works
 
 1. **Create Dedicated Schema Files**: Prefer having a dedicated schema `.graphql` file for each table. Check the `config.yaml` file under `graphqlSchema.files` to see how it's configured. It typically accepts wildcards (e.g., `schemas/*.graphql`), but may be configured to point at a single file.
-2. **Use Directives**: All available directives for defining your schema are defined in `node_modules/harperdb/schema.graphql`. Common directives include `@table`, `@export`, `@primaryKey`, `@indexed`, and `@relationship`.
+2. **Use Directives**: All available directives for defining your schema are defined in `node_modules/harper/schema.graphql`. Common directives include `@table`, `@export`, `@primaryKey`, `@indexed`, and `@relationship`.
 3. **Define Relationships**: Link tables together using the `@relationship` directive. For more details, see the [Defining Relationships](defining-relationships.md) skill.
 4. **Enable Automatic APIs**: If you add `@table @export` to a schema type, Harper automatically sets up REST and WebSocket APIs for basic CRUD operations against that table. For a detailed list of available endpoints and how to use them, see the [Automatic REST APIs](automatic-apis.md) skill.
    - `GET /{TableName}`: Describes the schema itself.

--- a/harper-best-practices/rules/caching.md
+++ b/harper-best-practices/rules/caching.md
@@ -32,7 +32,7 @@ type MyCache @table(expiration: 3600) @export {
 ### Resource Implementation
 
 ```js
-import { Resource, tables } from 'harperdb';
+import { Resource, tables } from 'harper';
 
 export class ThirdPartyAPI extends Resource {
 	async get() {

--- a/harper-best-practices/rules/checking-authentication.md
+++ b/harper-best-practices/rules/checking-authentication.md
@@ -13,7 +13,7 @@ Use this skill when you need to implement sign-in/sign-out functionality, protec
 
 ## How It Works
 
-1. **Configure Harper for Sessions**: Ensure `harperdb-config.yaml` has sessions enabled and local auto-authorization disabled for testing:
+1. **Configure Harper for Sessions**: Ensure `harper-config.yaml` has sessions enabled and local auto-authorization disabled for testing:
    ```yaml
    authentication:
      authorizeLocal: false

--- a/harper-best-practices/rules/custom-resources.md
+++ b/harper-best-practices/rules/custom-resources.md
@@ -15,10 +15,10 @@ Use this skill when the automatic CRUD operations provided by `@table @export` a
 
 1. **Check if a Custom Resource is Necessary**: Verify if [Automatic APIs](./automatic-apis.md) or [Extending Tables](./extending-tables.md) can satisfy the requirement first.
 2. **Create the Resource File**: Create a `.ts` or `.js` file in the directory specified by `jsResource` in `config.yaml` (typically `resources/`).
-3. **Define the Resource Class**: Export a class extending `Resource` from `harperdb`:
+3. **Define the Resource Class**: Export a class extending `Resource` from `harper`:
 
    ```typescript
-   import { type RequestTargetOrId, Resource } from 'harperdb';
+   import { type RequestTargetOrId, Resource } from 'harper';
 
    export class MyResource extends Resource {
    	async get(target?: RequestTargetOrId) {
@@ -34,7 +34,7 @@ Use this skill when the automatic CRUD operations provided by `@table @export` a
    - **Lowercase and Hyphens**: Use object keys to define custom paths: `export const bar = { 'foo-baz': Foo };` exposes endpoints at `/bar/foo-baz/`.
 6. **Access Tables (Optional)**: Import and use the `tables` object to interact with your data:
    ```typescript
-   import { tables } from 'harperdb';
+   import { tables } from 'harper';
    // ... inside a method
    const results = await tables.MyTable.list();
    ```

--- a/harper-best-practices/rules/deploying-to-harper-fabric.md
+++ b/harper-best-practices/rules/deploying-to-harper-fabric.md
@@ -35,11 +35,11 @@ Add the following scripts and dependencies to your `package.json`:
 {
 	"scripts": {
 		"deploy": "dotenv -- npm run deploy:component",
-		"deploy:component": "harperdb deploy_component . restart=rolling replicated=true"
+		"deploy:component": "harper deploy_component . restart=rolling replicated=true"
 	},
 	"devDependencies": {
 		"dotenv-cli": "^11.0.0",
-		"harperdb": "^4.7.20"
+		"harper": "^5.0.0"
 	}
 }
 ```
@@ -51,7 +51,7 @@ The `deploy` script is separated from `deploy:component` to ensure environment v
 - `deploy`: Uses `dotenv-cli` to load environment variables (like `CLI_TARGET`, `CLI_TARGET_USERNAME`, and `CLI_TARGET_PASSWORD`) before executing the next command.
 - `deploy:component`: The actual command that performs the deployment.
 
-By using `dotenv -- npm run deploy:component`, the environment variables are correctly set in the shell session before `harperdb deploy_component` is called, allowing it to authenticate with your cluster.
+By using `dotenv -- npm run deploy:component`, the environment variables are correctly set in the shell session before `harper deploy_component` is called, allowing it to authenticate with your cluster.
 
 ### 2. Configure GitHub Actions
 

--- a/harper-best-practices/rules/extending-tables.md
+++ b/harper-best-practices/rules/extending-tables.md
@@ -24,7 +24,7 @@ Use this skill when you need to add custom validation, side effects (like webhoo
 3. **Extend the Table Resource**: Export a class that extends `tables.YourTableName`:
 
    ```typescript
-   import { type RequestTargetOrId, tables } from 'harperdb';
+   import { type RequestTargetOrId, tables } from 'harper';
 
    export class MyTable extends tables.MyTable {
    	async post(target: RequestTargetOrId, record: any) {

--- a/harper-best-practices/rules/real-time-apps.md
+++ b/harper-best-practices/rules/real-time-apps.md
@@ -24,7 +24,7 @@ Use this skill when you need to stream live updates to clients, implement chat f
 ### Bi-directional WebSocket Resource
 
 ```typescript
-import { Resource, tables } from 'harperdb';
+import { Resource, tables } from 'harper';
 
 export class MySocket extends Resource {
 	async *connect(target, incomingMessages) {

--- a/harper-best-practices/rules/schema-design-tooling.md
+++ b/harper-best-practices/rules/schema-design-tooling.md
@@ -9,7 +9,7 @@ Harper uses GraphQL schemas to define database tables, relationships, and APIs. 
 
 ## Core Harper Directives
 
-Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harperdb/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
+Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harper/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
 
 ### Table Definition
 
@@ -43,7 +43,7 @@ Create a file named `graphql.config.yml` in your project root with the following
 
 ```yaml
 schema:
-  - 'node_modules/harperdb/schema.graphql'
+  - 'node_modules/harper/schema.graphql'
   - 'schema.graphql'
   - 'schemas/*.graphql'
 ```

--- a/harper-best-practices/rules/typescript-type-stripping.md
+++ b/harper-best-practices/rules/typescript-type-stripping.md
@@ -17,7 +17,7 @@ Use this skill when you want to write Harper Resources in TypeScript and have th
 2. **Name Files with `.ts`**: Create your resource files in the `resources/` directory with a `.ts` extension.
 3. **Use TypeScript Syntax**: Write your resource classes using standard TypeScript (interfaces, types, etc.).
    ```typescript
-   import { Resource } from 'harperdb';
+   import { Resource } from 'harper';
    export class MyResource extends Resource {
    	async get(): Promise<{ message: string }> {
    		return { message: 'Running TS directly!' };

--- a/harper-best-practices/rules/using-blob-datatype.md
+++ b/harper-best-practices/rules/using-blob-datatype.md
@@ -22,7 +22,7 @@ Use this skill when you need to store unstructured or large binary data (media, 
    ```
 2. **Create and Store Blobs**: Use `createBlob()` from Harper's globals to wrap Buffers or Streams:
    ```javascript
-   import { tables } from 'harperdb';
+   import { tables } from 'harper';
    const blob = createBlob(largeBuffer);
    await tables.MyTable.put('my-id', { data: blob });
    ```


### PR DESCRIPTION
## Summary

- Replaces all `harperdb` CLI command references (`harperdb deploy_component`, `harperdb run`) with `harper`
- Updates all package import references (`from 'harperdb'`) to `from 'harper'`
- Updates `node_modules/harperdb/schema.graphql` path references to `node_modules/harper/schema.graphql`
- Renames `harperdb-config.yaml` reference to `harper-config.yaml`
- Bumps example devDependency from `"harperdb": "^4.7.20"` to `"harper": "^5.0.0"`

## Files changed

`harper-best-practices/AGENTS.md` and 10 rules files under `harper-best-practices/rules/`.

The only remaining `harperdb` string in the repo is the `support@harperdb.io` contact email in `package.json`, which was intentionally left unchanged.

## Test plan

- [ ] Verify no `harperdb` package/CLI references remain: `grep -r "harperdb" harper-best-practices/`
- [ ] Confirm all import examples use `from 'harper'`
- [ ] Confirm CLI examples use `harper deploy_component` and `harper run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)