### PR TITLE
docs: add query conditions reference to programmatic-table-requests skill

### DIFF
--- a/harper-best-practices/rules/programmatic-table-requests.md
+++ b/harper-best-practices/rules/programmatic-table-requests.md
@@ -30,6 +30,7 @@ Use this skill when you need to perform database operations (CRUD, search, subsc
      // process record
    }
    ```
+   See the [Query Conditions](#query-conditions) section below for the full query object reference.
 5. **Real-time Subscriptions**: Use `subscribe(query)` to listen for changes:
    ```typescript
    for await (const event of tables.MyTable.subscribe(query)) {
@@ -37,6 +38,90 @@ Use this skill when you need to perform database operations (CRUD, search, subsc
    }
    ```
 6. **Publish Events**: Use `publish(id, message)` to trigger subscriptions without necessarily persisting data.
+
+## Query Conditions
+
+When passing a query to `search()`, `get()`, or `subscribe()`, use a query object with a `conditions` array.
+
+### Condition Object Shape
+
+| Property | Description |
+|---|---|
+| `attribute` | Field name, or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
+| `value` | The value to compare against |
+| `comparator` | One of the comparator strings below (default: `equals`) |
+| `operator` | `and` (default) or `or` — applies to a nested `conditions` block |
+| `conditions` | Nested array of condition objects for complex AND/OR logic |
+
+### Comparator Values
+
+Use these exact strings — incorrect comparator names will silently fail or error:
+
+| Comparator | Meaning |
+|---|---|
+| `equals` | Exact match (default) |
+| `not_equal` | Not equal |
+| `greater_than` | `>` |
+| `greater_than_equal` | `>=` |
+| `less_than` | `<` |
+| `less_than_equal` | `<=` |
+| `starts_with` | String starts with value |
+| `contains` | String contains value |
+| `ends_with` | String ends with value |
+| `between` | Value is between two bounds (pass `value` as `[min, max]`) |
+
+### Query Object Parameters
+
+| Property | Description |
+|---|---|
+| `conditions` | Array of condition objects |
+| `limit` | Maximum number of records to return |
+| `offset` | Number of records to skip (for pagination) |
+| `select` | Array of attribute names to return; supports `$id` and `$updatedtime` |
+| `sort` | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
+
+### Examples
+
+**Simple filter:**
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [{ attribute: 'price', comparator: 'less_than', value: 100 }],
+  limit: 20,
+})) { ... }
+```
+
+**AND + nested OR:**
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [
+    { attribute: 'price', comparator: 'less_than', value: 100 },
+    {
+      operator: 'or',
+      conditions: [
+        { attribute: 'rating', comparator: 'greater_than', value: 4 },
+        { attribute: 'featured', value: true },
+      ],
+    },
+  ],
+})) { ... }
+```
+
+**Relationship traversal:**
+```javascript
+for await (const record of tables.Book.search({
+  conditions: [{ attribute: ['brand', 'name'], comparator: 'equals', value: 'Harper' }],
+})) { ... }
+```
+
+**Sort and paginate:**
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [{ attribute: 'inStock', value: true }],
+  sort: { attribute: 'price', descending: false },
+  limit: 10,
+  offset: 20,
+})) { ... }
+```
 
 ## Cautions
 

--- a/harper-best-practices/rules/querying-rest-apis.md
+++ b/harper-best-practices/rules/querying-rest-apis.md
@@ -1,6 +1,6 @@
 ---
 name: querying-rest-apis
-description: How to filter, sort, and paginate Harper REST APIs via URL query strings and programmatic conditions.
+description: How to use query parameters to filter, sort, and paginate Harper REST APIs.
 ---
 
 # Querying REST APIs
@@ -9,9 +9,9 @@ Instructions for the agent to follow when querying Harper's REST APIs.
 
 ## When to Use
 
-Use this skill when you need to perform advanced data retrieval (filtering, sorting, pagination, joins) using Harper's automatic REST endpoints or programmatic table calls inside custom resources.
+Use this skill when you need to perform advanced data retrieval (filtering, sorting, pagination, joins) using Harper's automatic REST endpoints.
 
-## URL Query String Syntax
+## How It Works
 
 1. **Basic Filtering**: Use attribute names as query parameters: `GET /Table/?key=value`.
 2. **Use Comparison Operators**: Append operators like `gt`, `ge`, `lt`, `le`, `ne` using FIQL-style syntax: `GET /Table/?price=gt=100`.
@@ -25,89 +25,3 @@ Use this skill when you need to perform advanced data retrieval (filtering, sort
    - Example (desc): `GET /Table/?sort(-price)`
    - Example (combined): `GET /Table/?sort(-price,+name)`
 7. **Query Relationships**: Use dot syntax for tables linked with `@relationship`: `GET /Book/?author.name=Harper`.
-
-## Programmatic Conditions (Custom Resources)
-
-When querying tables inside custom resources (e.g., `tables.MyTable.search(query)`), use a query object with a `conditions` array instead of URL syntax.
-
-### Condition Object Shape
-
-Each entry in `conditions` has:
-
-| Property | Description |
-|---|---|
-| `attribute` | Field name (string), or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
-| `value` | The value to compare against |
-| `comparator` | One of the comparator strings below (default: `equals`) |
-| `operator` | `and` (default) or `or` — applies to a nested `conditions` block |
-| `conditions` | Nested array of condition objects for complex AND/OR logic |
-
-### Comparator Values
-
-Use these exact strings — incorrect comparator names will silently fail or error:
-
-| Comparator | Meaning |
-|---|---|
-| `equals` | Exact match (default) |
-| `not_equal` | Not equal |
-| `greater_than` | `>` |
-| `greater_than_equal` | `>=` |
-| `less_than` | `<` |
-| `less_than_equal` | `<=` |
-| `starts_with` | String starts with value |
-| `contains` | String contains value |
-| `ends_with` | String ends with value |
-| `between` | Value is between two bounds (pass `value` as `[min, max]`) |
-
-### Query Object Parameters
-
-| Property | Description |
-|---|---|
-| `conditions` | Array of condition objects (see above) |
-| `limit` | Maximum number of records to return |
-| `offset` | Number of records to skip (for pagination) |
-| `select` | Array of attribute names to return; supports `$id` and `$updatedtime` |
-| `sort` | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
-
-### Examples
-
-**Simple filter:**
-```javascript
-const results = await tables.Product.search({
-  conditions: [{ attribute: 'price', comparator: 'less_than', value: 100 }],
-  limit: 20,
-});
-```
-
-**AND + nested OR:**
-```javascript
-const results = await tables.Product.search({
-  conditions: [
-    { attribute: 'price', comparator: 'less_than', value: 100 },
-    {
-      operator: 'or',
-      conditions: [
-        { attribute: 'rating', comparator: 'greater_than', value: 4 },
-        { attribute: 'featured', value: true },
-      ],
-    },
-  ],
-});
-```
-
-**Relationship traversal:**
-```javascript
-const results = await tables.Book.search({
-  conditions: [{ attribute: ['brand', 'name'], comparator: 'equals', value: 'Harper' }],
-});
-```
-
-**Sort and paginate:**
-```javascript
-const results = await tables.Product.search({
-  conditions: [{ attribute: 'inStock', value: true }],
-  sort: { attribute: 'price', descending: false },
-  limit: 10,
-  offset: 20,
-});
-```

--- a/harper-best-practices/rules/querying-rest-apis.md
+++ b/harper-best-practices/rules/querying-rest-apis.md
@@ -1,6 +1,6 @@
 ---
 name: querying-rest-apis
-description: How to use query parameters to filter, sort, and paginate Harper REST APIs.
+description: How to filter, sort, and paginate Harper REST APIs via URL query strings and programmatic conditions.
 ---
 
 # Querying REST APIs
@@ -9,9 +9,9 @@ Instructions for the agent to follow when querying Harper's REST APIs.
 
 ## When to Use
 
-Use this skill when you need to perform advanced data retrieval (filtering, sorting, pagination, joins) using Harper's automatic REST endpoints.
+Use this skill when you need to perform advanced data retrieval (filtering, sorting, pagination, joins) using Harper's automatic REST endpoints or programmatic table calls inside custom resources.
 
-## How It Works
+## URL Query String Syntax
 
 1. **Basic Filtering**: Use attribute names as query parameters: `GET /Table/?key=value`.
 2. **Use Comparison Operators**: Append operators like `gt`, `ge`, `lt`, `le`, `ne` using FIQL-style syntax: `GET /Table/?price=gt=100`.
@@ -25,3 +25,89 @@ Use this skill when you need to perform advanced data retrieval (filtering, sort
    - Example (desc): `GET /Table/?sort(-price)`
    - Example (combined): `GET /Table/?sort(-price,+name)`
 7. **Query Relationships**: Use dot syntax for tables linked with `@relationship`: `GET /Book/?author.name=Harper`.
+
+## Programmatic Conditions (Custom Resources)
+
+When querying tables inside custom resources (e.g., `tables.MyTable.search(query)`), use a query object with a `conditions` array instead of URL syntax.
+
+### Condition Object Shape
+
+Each entry in `conditions` has:
+
+| Property | Description |
+|---|---|
+| `attribute` | Field name (string), or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
+| `value` | The value to compare against |
+| `comparator` | One of the comparator strings below (default: `equals`) |
+| `operator` | `and` (default) or `or` — applies to a nested `conditions` block |
+| `conditions` | Nested array of condition objects for complex AND/OR logic |
+
+### Comparator Values
+
+Use these exact strings — incorrect comparator names will silently fail or error:
+
+| Comparator | Meaning |
+|---|---|
+| `equals` | Exact match (default) |
+| `not_equal` | Not equal |
+| `greater_than` | `>` |
+| `greater_than_equal` | `>=` |
+| `less_than` | `<` |
+| `less_than_equal` | `<=` |
+| `starts_with` | String starts with value |
+| `contains` | String contains value |
+| `ends_with` | String ends with value |
+| `between` | Value is between two bounds (pass `value` as `[min, max]`) |
+
+### Query Object Parameters
+
+| Property | Description |
+|---|---|
+| `conditions` | Array of condition objects (see above) |
+| `limit` | Maximum number of records to return |
+| `offset` | Number of records to skip (for pagination) |
+| `select` | Array of attribute names to return; supports `$id` and `$updatedtime` |
+| `sort` | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
+
+### Examples
+
+**Simple filter:**
+```javascript
+const results = await tables.Product.search({
+  conditions: [{ attribute: 'price', comparator: 'less_than', value: 100 }],
+  limit: 20,
+});
+```
+
+**AND + nested OR:**
+```javascript
+const results = await tables.Product.search({
+  conditions: [
+    { attribute: 'price', comparator: 'less_than', value: 100 },
+    {
+      operator: 'or',
+      conditions: [
+        { attribute: 'rating', comparator: 'greater_than', value: 4 },
+        { attribute: 'featured', value: true },
+      ],
+    },
+  ],
+});
+```
+
+**Relationship traversal:**
+```javascript
+const results = await tables.Book.search({
+  conditions: [{ attribute: ['brand', 'name'], comparator: 'equals', value: 'Harper' }],
+});
+```
+
+**Sort and paginate:**
+```javascript
+const results = await tables.Product.search({
+  conditions: [{ attribute: 'inStock', value: true }],
+  sort: { attribute: 'price', descending: false },
+  limit: 10,
+  offset: 20,
+});
+```


### PR DESCRIPTION
## Summary

- Adds a **Query Conditions** section to `programmatic-table-requests.md` — the right home since conditions are only relevant when using the JS table API (`search()`, `get()`, `subscribe()`) inside custom resources
- Documents the `conditions` array shape (`attribute`, `value`, `comparator`, `operator`, nested `conditions`)
- Provides a reference table of all valid **comparator strings** (`equals`, `not_equal`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `starts_with`, `contains`, `ends_with`, `between`) — these differ from URL/FIQL syntax and must be exact
- Documents top-level query object params (`limit`, `offset`, `select`, `sort`)
- Includes annotated examples for simple filters, AND+OR nesting, relationship traversal, and sort+paginate
- `querying-rest-apis.md` is unchanged (URL/FIQL syntax only)

## Motivation

An agent failed to build working queries inside a custom resource because there was no reference for the programmatic conditions API. The comparator names (`equals`, `greater_than`, etc.) differ from URL/FIQL equivalents (`eq`, `gt`) and incorrect names silently fail.

## Test plan

- [ ] Confirm comparator table matches [Harper v5 resource API docs](https://docs.harperdb.io/reference/v5/resources/resource-api#conditions)
- [ ] Verify examples use correct `search()` streaming pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)