### PR TITLE
chore: enforce formatting in CI and fix drifted file

### DIFF
--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -16,7 +16,11 @@ npm install
 
 ## Development workflow
 
-- Validate changes: `npm run validate`
+- Format source files: `npm run format` — formats in place using oxfmt. Run this before committing if you've edited markdown, JSON, or other formatter-managed files.
+- Check formatting without writing: `npm run format:check` — exits non-zero if any file would be changed by `npm run format`. This is the gate enforced by CI.
+- Validate everything: `npm run validate` — runs `format:check`, then `build`, then both skill validators (`validate-skills.mjs` for the legacy schema checks, `validate-generated.mjs` for manifest ↔ frontmatter reconciliation defined under `scripts/generation/`).
+
+The pipeline is intentionally ordered so `format:check` runs first. CI will fail loudly on formatting drift rather than silently auto-fixing it.
 
 ## Creating Skills
 

--- a/harper-best-practices/rules/programmatic-table-requests.md
+++ b/harper-best-practices/rules/programmatic-table-requests.md
@@ -47,44 +47,45 @@ When passing a query to `search()`, `get()`, or `subscribe()`, use a query objec
 
 ### Condition Object Shape
 
-| Property | Description |
-|---|---|
-| `attribute` | Field name, or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
-| `value` | The value to compare against |
-| `comparator` | One of the comparator strings below (default: `equals`) |
-| `operator` | `and` (default) or `or` — applies to a nested `conditions` block |
-| `conditions` | Nested array of condition objects for complex AND/OR logic |
+| Property     | Description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `attribute`  | Field name, or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
+| `value`      | The value to compare against                                                               |
+| `comparator` | One of the comparator strings below (default: `equals`)                                    |
+| `operator`   | `and` (default) or `or` — applies to a nested `conditions` block                           |
+| `conditions` | Nested array of condition objects for complex AND/OR logic                                 |
 
 ### Comparator Values
 
 Use these exact strings — incorrect comparator names will silently fail or error:
 
-| Comparator | Meaning |
-|---|---|
-| `equals` | Exact match (default) |
-| `not_equal` | Not equal |
-| `greater_than` | `>` |
-| `greater_than_equal` | `>=` |
-| `less_than` | `<` |
-| `less_than_equal` | `<=` |
-| `starts_with` | String starts with value |
-| `contains` | String contains value |
-| `ends_with` | String ends with value |
-| `between` | Value is between two bounds (pass `value` as `[min, max]`) |
+| Comparator           | Meaning                                                    |
+| -------------------- | ---------------------------------------------------------- |
+| `equals`             | Exact match (default)                                      |
+| `not_equal`          | Not equal                                                  |
+| `greater_than`       | `>`                                                        |
+| `greater_than_equal` | `>=`                                                       |
+| `less_than`          | `<`                                                        |
+| `less_than_equal`    | `<=`                                                       |
+| `starts_with`        | String starts with value                                   |
+| `contains`           | String contains value                                      |
+| `ends_with`          | String ends with value                                     |
+| `between`            | Value is between two bounds (pass `value` as `[min, max]`) |
 
 ### Query Object Parameters
 
-| Property | Description |
-|---|---|
-| `conditions` | Array of condition objects |
-| `limit` | Maximum number of records to return |
-| `offset` | Number of records to skip (for pagination) |
-| `select` | Array of attribute names to return; supports `$id` and `$updatedtime` |
-| `sort` | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
+| Property     | Description                                                                          |
+| ------------ | ------------------------------------------------------------------------------------ |
+| `conditions` | Array of condition objects                                                           |
+| `limit`      | Maximum number of records to return                                                  |
+| `offset`     | Number of records to skip (for pagination)                                           |
+| `select`     | Array of attribute names to return; supports `$id` and `$updatedtime`                |
+| `sort`       | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
 
 ### Examples
 
 **Simple filter:**
+
 ```javascript
 for await (const record of tables.Product.search({
   conditions: [{ attribute: 'price', comparator: 'less_than', value: 100 }],
@@ -93,6 +94,7 @@ for await (const record of tables.Product.search({
 ```
 
 **AND + nested OR:**
+
 ```javascript
 for await (const record of tables.Product.search({
   conditions: [
@@ -109,6 +111,7 @@ for await (const record of tables.Product.search({
 ```
 
 **Relationship traversal:**
+
 ```javascript
 for await (const record of tables.Book.search({
   conditions: [{ attribute: ['brand', 'name'], comparator: 'equals', value: 'Harper' }],
@@ -116,6 +119,7 @@ for await (const record of tables.Book.search({
 ```
 
 **Sort and paginate:**
+
 ```javascript
 for await (const record of tables.Product.search({
   conditions: [{ attribute: 'inStock', value: true }],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 	"scripts": {
 		"build": "node scripts/build.mjs",
 		"format": "oxfmt",
-		"validate": "npm run build && oxfmt --check && node scripts/validate-skills.mjs && node scripts/generation/validate-generated.mjs"
+		"format:check": "oxfmt --check",
+		"validate": "npm run format:check && npm run build && node scripts/validate-skills.mjs && node scripts/generation/validate-generated.mjs"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^20.4.1",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -71,12 +71,12 @@ export declare const skillSummary: string;
 `,
 		);
 
-		try {
-			const { execSync } = await import('node:child_process');
-			execSync('npm run format', { stdio: 'inherit' });
-		} catch (error) {
-			console.warn('Could not run format after build:', error.message);
-		}
+		// Intentionally no formatter pass. dist/ is in .gitignore and consumed
+		// by npm; it is machine-generated output, not source. Running the
+		// formatter from here previously had the unintended side effect of
+		// silently reformatting source files in CI working trees, which
+		// masked formatting drift in committed files. Use `npm run format`
+		// explicitly when you want to format source.
 
 		console.log('Build completed successfully.');
 	} catch (error) {


### PR DESCRIPTION
## What and why

The repo's `validate` pipeline had a structural flaw that **silently masked formatting drift** in committed source files. This PR fixes the root cause and resyncs the one file that had drifted under the old behavior.

### The flaw

```
validate = build && oxfmt --check && validators
build    = node scripts/build.mjs  (which ran `npm run format` at the end)
```

Every CI run invoked the formatter against source files *before* checking, so the `--check` stage always passed against the just-reformatted tree. Committed files with format drift would silently get reformatted in CI's working copy and the check would report green. Drift accumulated until someone noticed in a local `git diff`.

We saw this concretely after #35 (plan) and #36 (Phase 0) merged: `programmatic-table-requests.md` from the intervening #34 had oxfmt-incompliant markdown tables that were never caught, and `npm run build` kept silently reformatting it locally on every run.

### Structural fix

- **`scripts/build.mjs`** — remove the trailing `npm run format` call. `dist/` is in `.gitignore`, so the formatter was actually skipping it (`oxfmt` honors gitignore); the only thing the call did in practice was the unintended source-file side effect. `dist/` is machine-generated output consumed by npm; it doesn't need to match the formatter.
- **`package.json`** — add a `format:check` script (`oxfmt --check`), and reorder `validate` to run `format:check` **first**, before build:

  | | Before | After |
  |---|---|---|
  | `validate` | `build && oxfmt --check && validators` | `format:check && build && validators` |

  The gate now sees the committed file content, not a freshly reformatted version of it.
- **`.github/CONTRIBUTING.MD`** — document the npm scripts and the format-check-first ordering so contributors know to run `npm run format` before committing.

### One drifted file resynced

`harper-best-practices/rules/programmatic-table-requests.md` — pure formatter pass (markdown table column alignment). No content change. This is the file that had been drifting under the old behavior.

## Verification

- `npm run validate` exits 0 on the current tree ✓
- Introducing a deliberate format violation (trailing whitespace on a heading) causes `npm run validate` to exit 1 with a clear error, blocking the rest of the pipeline ✓
- `dist/` output is unchanged (same JSON.stringify template output as before; the formatter never touched it).

## Risk / blast radius

Low — three small changes (one bug-fix delete, one script reorder, one drifted file resync). The CI workflow itself doesn't change; it still calls `npm run validate`, just with the corrected internal ordering. No new dependencies. No changes to skill content semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)