### PR TITLE
feat: Phase 2 — docs-driven rule generator (generate + direct modes)

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -121,6 +121,8 @@ jobs:
           git checkout -B "$BRANCH"
           git add harper-best-practices
           git commit -m "docs: regenerate rules from documentation@${SHORT}"
+          # Force is intentional: each run replaces the rolling branch's prior
+          # commit in place so the open sync PR always reflects the latest docs.
           git push --force origin "$BRANCH"
 
           STATE=$(gh pr view "$BRANCH" --json state --jq .state 2>/dev/null || echo "")

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -33,11 +33,21 @@ jobs:
     name: Generate and open sync PR
     runs-on: ubuntu-latest
     steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SKILLS_SYNC_APP_ID }}
+          private-key: ${{ secrets.SKILLS_SYNC_APP_PRIVATE_KEY }}
+
       - name: Checkout skills
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: skills
           fetch-depth: 0
+          # Use the App token so the branch push (and thus the auto-PR) is
+          # attributed to the App and triggers the validate workflow.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Resolve docs ref
         id: docsref
@@ -52,9 +62,7 @@ jobs:
           repository: HarperFast/documentation
           ref: ${{ steps.docsref.outputs.ref }}
           path: documentation
-          # DOCS_REPO_TOKEN is only needed if the documentation repo is private.
-          # Falls back to the job token (works when documentation is public).
-          token: ${{ secrets.DOCS_REPO_TOKEN || github.token }}
+          # documentation is a public repo, so the default job token reads it.
           fetch-depth: 1
 
       - name: Setup Node.js
@@ -89,10 +97,10 @@ jobs:
       - name: Open or update sync PR
         working-directory: skills
         env:
-          # SKILLS_BOT_TOKEN (a PAT/App token) makes the auto-PR trigger the
-          # validate workflow; PRs opened by the default job token do not
-          # trigger other workflows. Falls back to the job token if unset.
-          GH_TOKEN: ${{ secrets.SKILLS_BOT_TOKEN || github.token }}
+          # The App token (not the default job token) ensures the auto-PR
+          # triggers the validate workflow — PRs opened by the job token do
+          # not trigger other workflows.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           # The generator only writes rule bodies + AGENTS.md under this path.
@@ -105,8 +113,8 @@ jobs:
           SHORT=${DOCS_SHA:0:7}
           BRANCH="auto/docs-sync"
 
-          git config user.name "harper-skills-bot"
-          git config user.email "skills-bot@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
           # Single rolling branch: at most one open auto-sync PR at a time. If
           # docs change again before it merges, the same PR is force-updated.

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,129 @@
+name: Generate Rules from Docs
+
+# Regenerates docs-driven skill rules and opens a sync PR. Triggered when the
+# documentation repo deploys (repository_dispatch), on a weekly safety-net
+# cron, or manually. See docs/plans/docs-driven-skills.md (Phase 2).
+#
+# Offline-first: the docs repo is checked out and built in-job; the generator
+# reads the local build output and never fetches docs over the network.
+
+on:
+  repository_dispatch:
+    types: [docs-updated]
+  schedule:
+    # Mondays 09:17 UTC — safety net in case a dispatch is missed.
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      docs_ref:
+        description: 'Docs ref to build (branch, tag, or commit SHA)'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: generate-rules
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: Generate and open sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout skills
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: skills
+          fetch-depth: 0
+
+      - name: Resolve docs ref
+        id: docsref
+        run: |
+          REF="${{ github.event.client_payload.sha || github.event.inputs.docs_ref || 'main' }}"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "Docs ref: $REF"
+
+      - name: Checkout documentation
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: HarperFast/documentation
+          ref: ${{ steps.docsref.outputs.ref }}
+          path: documentation
+          # DOCS_REPO_TOKEN is only needed if the documentation repo is private.
+          # Falls back to the job token (works when documentation is public).
+          token: ${{ secrets.DOCS_REPO_TOKEN || github.token }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: skills/.nvmrc
+
+      - name: Build documentation (produces flat-markdown under build/)
+        working-directory: documentation
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install skills dependencies
+        working-directory: skills
+        run: npm ci
+
+      - name: Generate rules
+        working-directory: skills
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: npm run generate -- --docs-path ../documentation
+
+      - name: Validate
+        working-directory: skills
+        run: |
+          npm run format:check
+          npm run build
+          node scripts/validate-skills.mjs
+          node scripts/generation/validate-generated.mjs --docs-path ../documentation
+
+      - name: Open or update sync PR
+        working-directory: skills
+        env:
+          # SKILLS_BOT_TOKEN (a PAT/App token) makes the auto-PR trigger the
+          # validate workflow; PRs opened by the default job token do not
+          # trigger other workflows. Falls back to the job token if unset.
+          GH_TOKEN: ${{ secrets.SKILLS_BOT_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          # The generator only writes rule bodies + AGENTS.md under this path.
+          if git diff --quiet -- harper-best-practices; then
+            echo "No changes — skills are already in sync with docs."
+            exit 0
+          fi
+
+          DOCS_SHA=$(git -C ../documentation rev-parse HEAD)
+          SHORT=${DOCS_SHA:0:7}
+          BRANCH="auto/docs-sync"
+
+          git config user.name "harper-skills-bot"
+          git config user.email "skills-bot@users.noreply.github.com"
+
+          # Single rolling branch: at most one open auto-sync PR at a time. If
+          # docs change again before it merges, the same PR is force-updated.
+          git checkout -B "$BRANCH"
+          git add harper-best-practices
+          git commit -m "docs: regenerate rules from documentation@${SHORT}"
+          git push --force origin "$BRANCH"
+
+          STATE=$(gh pr view "$BRANCH" --json state --jq .state 2>/dev/null || echo "")
+          if [ "$STATE" = "OPEN" ]; then
+            echo "Existing sync PR updated."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "docs: regenerate rules from documentation@${SHORT}" \
+              --body "Automated regeneration of docs-driven skill rules from \`HarperFast/documentation@${SHORT}\`.
+
+          Produced by \`.github/workflows/generate.yaml\`. Review the diff as you would any rule change — the generator reads the docs build output and rewrites \`mode: generate\` / imports \`mode: direct\` rule bodies, then reassembles AGENTS.md. See docs/plans/docs-driven-skills.md.
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 dist
+.env

--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -926,9 +926,9 @@ Create a `.github/workflows/deploy.yaml` file with the following content:
 name: Deploy to Harper Fabric
 on:
   workflow_dispatch:
-###  push:
-###    branches:
-###      - main
+#  push:
+#    branches:
+#      - main
 concurrency:
   group: main
   cancel-in-progress: false

--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -2,40 +2,7 @@
 
 Guidelines for building scalable, secure, and performant applications on Harper. These practices cover everything from initial schema design to advanced deployment strategies.
 
----
-
-## Table of Contents
-
-1. [Schema & Data Design](#1-schema--data-design) — **HIGH**
-   - 1.1 [Adding Tables with Schemas](#11-adding-tables-with-schemas)
-   - 1.2 [Schema Design & Tooling](#12-schema-design--tooling)
-   - 1.3 [Defining Relationships](#13-defining-relationships)
-   - 1.4 [Vector Indexing](#14-vector-indexing)
-   - 1.5 [Using Blobs](#15-using-blobs)
-   - 1.6 [Handling Binary Data](#16-handling-binary-data)
-2. [API & Communication](#2-api--communication) — **HIGH**
-   - 2.1 [Automatic REST APIs](#21-automatic-rest-apis)
-   - 2.2 [Querying REST APIs](#22-querying-rest-apis)
-   - 2.3 [Real-time Applications](#23-real-time-applications)
-   - 2.4 [Checking Authentication](#24-checking-authentication)
-3. [Logic & Extension](#3-logic--extension) — **MEDIUM**
-   - 3.1 [Custom Resources](#31-custom-resources)
-   - 3.2 [Extending Table Resources](#32-extending-table-resources)
-   - 3.3 [Programmatic Table Requests](#33-programmatic-table-requests)
-   - 3.4 [TypeScript Type Stripping](#34-typescript-type-stripping)
-   - 3.5 [Caching](#35-caching)
-4. [Infrastructure & Ops](#4-infrastructure--ops) — **MEDIUM**
-   - 4.1 [Creating Harper Applications](#41-creating-harper-applications)
-   - 4.2 [Creating a Fabric Account and Cluster](#42-creating-a-fabric-account-and-cluster)
-   - 4.3 [Deploying to Harper Fabric](#43-deploying-to-harper-fabric)
-   - 4.4 [Serving Web Content](#44-serving-web-content)
-   - 4.5 [Logging Best Practices](#45-logging-best-practices)
-
----
-
 ## 1. Schema & Data Design
-
-**Impact: HIGH**
 
 ### 1.1 Adding Tables with Schemas
 
@@ -49,11 +16,21 @@ Use this skill when you need to define new data structures or modify existing on
 
 1. **Create Dedicated Schema Files**: Prefer having a dedicated schema `.graphql` file for each table. Check the `config.yaml` file under `graphqlSchema.files` to see how it's configured. It typically accepts wildcards (e.g., `schemas/*.graphql`), but may be configured to point at a single file.
 2. **Use Directives**: All available directives for defining your schema are defined in `node_modules/harper/schema.graphql`. Common directives include `@table`, `@export`, `@primaryKey`, `@indexed`, and `@relationship`.
-3. **Define Relationships**: Link tables together using the `@relationship` directive.
-4. **Enable Automatic APIs**: If you add `@table @export` to a schema type, Harper automatically sets up REST and WebSocket APIs for basic CRUD operations against that table. **Important**: REST endpoints also require `rest: true` in `config.yaml` — without it, `@export`ed tables will not respond to HTTP requests.
-5. **Consider Table Extensions**: If you are going to extend the table in your resources, then do not `@export` the table from the schema.
+3. **Define Relationships**: Link tables together using the `@relationship` directive. For more details, see the [Defining Relationships](defining-relationships.md) skill.
+4. **Enable Automatic APIs**: If you add `@table @export` to a schema type, Harper automatically sets up REST and WebSocket APIs for basic CRUD operations against that table. **Important**: REST endpoints also require `rest: true` in `config.yaml` — without it, `@export`ed tables will not respond to HTTP requests. For a detailed list of available endpoints and how to use them, see the [Automatic REST APIs](automatic-apis.md) skill.
+   - `GET /{TableName}`: Describes the schema itself.
+   - `GET /{TableName}/`: Lists all records (supports filtering, sorting, and pagination via query parameters). See the [Querying REST APIs](querying-rest-apis.md) skill for details.
+   - `GET /{TableName}/{id}`: Retrieves a single record by its ID.
+   - `POST /{TableName}/`: Creates a new record.
+   - `PUT /{TableName}/{id}`: Updates an existing record.
+   - `PATCH /{TableName}/{id}`: Performs a partial update on a record.
+   - `DELETE /{TableName}/`: Deletes all records or filtered records.
+   - `DELETE /{TableName}/{id}`: Deletes a single record by its ID.
+5. **Consider Table Extensions**: If you are going to [extend the table](./extending-tables.md) in your resources, then do not `@export` the table from the schema.
 
-#### Example
+#### Examples
+
+In a hypothetical `schemas/ExamplePerson.graphql`:
 
 ```graphql
 type ExamplePerson @table @export {
@@ -129,16 +106,16 @@ my-harper-app/
 
 ### 1.3 Defining Relationships
 
-Using the `@relationship` directive to link tables.
+Instructions for the agent to follow when defining relationships between Harper tables.
 
 #### When to Use
 
-Use this when you have two or more tables that need to be logically linked (e.g., a "Product" table and a "Category" table).
+Use this skill when you need to link data across different tables, enabling automatic joins and efficient related-data fetching via REST APIs.
 
 #### How It Works
 
 1. **Identify the Relationship Type**: Determine if it's one-to-one, many-to-one, or one-to-many.
-2. **Apply the `@relationship` Directive**: In your GraphQL schema, use the `@relationship` directive on the field that links to another table.
+2. **Use the `@relationship` Directive**: Apply it to a field in your GraphQL schema.
    - **Many-to-One (Current table holds FK)**: Use `from`.
      ```graphql
      type Book @table @export {
@@ -153,262 +130,755 @@ Use this when you have two or more tables that need to be logically linked (e.g.
      }
      ```
 3. **Query with Relationships**: Use dot syntax in REST API calls for filtering or the `select()` operator for including related data.
-
-#### Example
-
-```graphql
-type Product @table @export {
-	id: ID @primaryKey
-	name: String
-	categoryId: ID
-	category: Category @relationship(from: "categoryId")
-}
-
-type Category @table @export {
-	id: ID @primaryKey
-	name: String
-	products: [Product] @relationship(to: "categoryId")
-}
-```
+   - Example Filter: `GET /Book/?author.name=Harper`
+   - Example Select: `GET /Author/?select(name,books(title))`
 
 ### 1.4 Vector Indexing
 
-How to define and use vector indexes for efficient similarity search.
+Instructions for the agent to follow when enabling and querying vector indexes for similarity search in Harper using the HNSW algorithm.
 
 #### When to Use
 
-Use this when you need to perform similarity searches on high-dimensional data, such as image embeddings, text embeddings, or any other numeric vectors.
+Apply this rule when adding a vector index to a Harper table schema to support approximate nearest-neighbor (similarity) search on high-dimensional float arrays. Use it whenever a query requires ranking results by vector similarity, optionally combined with filter conditions.
 
 #### How It Works
 
-1. **Define the Vector Field**: In your GraphQL schema, define a field with a list of floats (e.g., `[Float]`).
-2. **Apply the `@indexed` Directive**: Use the `@indexed` directive on the vector field and specify the index type as `HNSW`.
-3. **Configure the Index (Optional)**: You can provide additional configuration for the vector index, such as the distance metric (e.g., `cosine`, `euclidean`).
-4. **Querying**: Use the `vector` operator in your REST or programmatic requests to perform similarity searches.
+1. **Define the table schema with a vector index**: Add `@indexed(type: "HNSW")` to a `[Float]` attribute on a `@table` type. See [adding-tables-with-schemas](adding-tables-with-schemas.md) for general schema setup.
 
-#### Example
+   ```graphql
+   type Document @table {
+   	id: Long @primaryKey
+   	textEmbeddings: [Float] @indexed(type: "HNSW")
+   }
+   ```
+
+2. **Query by nearest neighbors**: Call `.search()` with a `sort` parameter specifying the indexed `attribute` and a `target` vector. The `target` is the query vector to compare against.
+
+   ```javascript
+   let results = Document.search({
+   	sort: { attribute: 'textEmbeddings', target: searchVector },
+   	limit: 5,
+   });
+   ```
+
+3. **Combine with filter conditions**: Add a `conditions` array alongside `sort` to filter results before ranking by similarity.
+
+   ```javascript
+   let results = Document.search({
+   	conditions: [{ attribute: 'price', comparator: 'lt', value: 50 }],
+   	sort: { attribute: 'textEmbeddings', target: searchVector },
+   	limit: 5,
+   });
+   ```
+
+4. **Tune HNSW parameters**: Pass additional parameters directly in the `@indexed` directive to control index quality and performance.
+
+   | Parameter              | Default           | Description                                                                                         |
+   | ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------- |
+   | `distance`             | `"cosine"`        | Distance function: `"euclidean"` or `"cosine"` (negative cosine similarity)                         |
+   | `efConstruction`       | `100`             | Max nodes explored during index construction. Higher = better recall, lower = better performance    |
+   | `M`                    | `16`              | Preferred connections per graph layer. Higher = more space, better recall for high-dimensional data |
+   | `optimizeRouting`      | `0.5`             | Heuristic aggressiveness for omitting redundant connections (0 = off, 1 = most aggressive)          |
+   | `mL`                   | computed from `M` | Normalization factor for level generation                                                           |
+   | `efSearchConstruction` | `50`              | Max nodes explored during search                                                                    |
+
+#### Examples
+
+Schema with default settings:
 
 ```graphql
-type Document @table @export {
-	id: ID @primaryKey
-	content: String
-	embedding: [Float] @indexed(type: "HNSW")
+type Document @table {
+	id: Long @primaryKey
+	textEmbeddings: [Float] @indexed(type: "HNSW")
 }
 ```
 
-### 1.5 Using Blobs
+Schema with custom parameters (euclidean distance, routing disabled, higher search recall):
 
-How to store and retrieve large data in Harper.
+```graphql
+type Document @table {
+	id: Long @primaryKey
+	textEmbeddings: [Float]
+		@indexed(type: "HNSW", distance: "euclidean", optimizeRouting: 0, efSearchConstruction: 100)
+}
+```
+
+Filtered nearest-neighbor search:
+
+```javascript
+let results = Document.search({
+	conditions: [{ attribute: 'price', comparator: 'lt', value: 50 }],
+	sort: { attribute: 'textEmbeddings', target: searchVector },
+	limit: 5,
+});
+```
+
+#### Notes
+
+- The default `distance` function is `cosine`. Use `"euclidean"` when your vectors are not normalized or when Euclidean geometry better fits your use case.
+- Increasing `efConstruction` improves index recall at the cost of build performance.
+- `mL` is computed automatically from `M` unless explicitly overridden.
+- Always pair `sort` with a `limit` to bound the number of nearest-neighbor results returned.
+
+### 1.5 Using Blob Datatype
+
+Instructions for the agent to follow when working with the Blob data type in Harper.
 
 #### When to Use
 
-Use this when you need to store large, unstructured data such as files, images, or large text documents that exceed the typical size of a standard database field.
+Use this skill when you need to store unstructured or large binary data (media, documents) that is too large for standard JSON fields. Blobs provide efficient storage and integrated streaming support.
 
 #### How It Works
 
-1. **Define the Blob Field**: Use the `Blob` scalar type in your GraphQL schema.
-2. **Storing Data**: Send the data as a buffer or a stream when creating or updating a record.
-3. **Retrieving Data**: Access the blob field, which will return the data as a stream or buffer.
+1. **Define Blob Fields**: In your GraphQL schema, use the `Blob` type:
+   ```graphql
+   type MyTable @table {
+   	id: ID @primaryKey
+   	data: Blob
+   }
+   ```
+2. **Create and Store Blobs**: Use `createBlob()` from Harper's globals to wrap Buffers or Streams:
+   ```javascript
+   import { tables } from 'harper';
+   const blob = createBlob(largeBuffer);
+   await tables.MyTable.put('my-id', { data: blob });
+   ```
+3. **Use Streaming (Optional)**: For very large files, pass a stream to `createBlob()` to avoid loading the entire file into memory.
+4. **Read Blob Data**: Retrieve the record and use `.bytes()` or streaming interfaces on the blob field:
+   ```javascript
+   const record = await tables.MyTable.get('my-id');
+   const buffer = await record.data.bytes();
+   ```
+5. **Ensure Write Completion**: Use `saveBeforeCommit: true` in `createBlob` options if you need the blob fully written before the record is committed.
+6. **Handle Errors**: Attach error listeners to the blob object to handle streaming failures.
 
 ### 1.6 Handling Binary Data
 
-How to store and serve binary data like images or MP3s.
+Instructions for the agent to follow when handling binary data in Harper.
 
 #### When to Use
 
-Use this when your application needs to handle binary files, particularly for storage and retrieval.
+Use this skill when you need to store binary files (images, audio, etc.) in the database or serve them back to clients via REST endpoints.
 
 #### How It Works
 
-1. **Use the `Blob` type**: As with general large data, the `Blob` type is best for binary files. Ensure you store and retrieve the appropriate MIME type (e.g., `image/jpeg`, `audio/mpeg`) for the data.
-2. **Streaming**: For large files, use streaming to minimize memory usage during upload and download.
-3. **MIME Types**: Store the MIME type alongside the binary data to ensure it is served correctly by your application logic.
+1. **Store Binary Data**: In your resource's `post` or `put` method, convert incoming data to Buffers and then to Blobs using `createBlob` from Harper's globals. Include the MIME type if available:
 
----
+   ```typescript
+   async post(target, record) {
+     if (record.data) {
+       record.data = createBlob(Buffer.from(record.data, record.encoding || 'base64'), {
+         type: record.contentType || 'application/octet-stream',
+       });
+     }
+     return super.post(target, record);
+   }
+   ```
+
+2. **Serve Binary Data**: In your resource's `get` method, return a response object with the appropriate `Content-Type` and the binary data in the `body`:
+   ```typescript
+   async get(target) {
+    const record = await super.get(target);
+    if (record?.data) {
+      return {
+        status: 200,
+        headers: { 'Content-Type': record.data.type || 'application/octet-stream' },
+        body: record.data,
+      };
+    }
+    return record;
+   }
+   ```
+3. **Use the Blob Type**: Ensure your GraphQL schema uses the `Blob` scalar for binary fields.
 
 ## 2. API & Communication
 
-**Impact: HIGH**
+### 2.1 Automatic APIs
 
-### 2.1 Automatic REST APIs
+Instructions for the agent to follow when utilizing Harper's automatic APIs.
 
-Details on the CRUD endpoints automatically generated for exported tables.
+#### When to Use
 
-#### Endpoints
+Use this skill when you want to interact with Harper tables via REST or WebSockets without writing custom resource logic. This is ideal for basic CRUD operations and real-time updates.
 
-- `GET /{TableName}`: Describes the schema.
-- `GET /{TableName}/`: Lists records (supports filtering/sorting).
-- `GET /{TableName}/{id}`: Gets a record by ID.
-- `POST /{TableName}/`: Creates a record.
-- `PUT /{TableName}/{id}`: Updates a record.
-- `PATCH /{TableName}/{id}`: Partial update.
-- `DELETE /{TableName}/`: Deletes records.
-- `DELETE /{TableName}/{id}`: Deletes by ID.
+#### How It Works
+
+1. **Enable REST in `config.yaml`**: REST endpoints are **not active by default**. You must explicitly enable them:
+   ```yaml
+   rest: true
+   ```
+   Without this, `@export`ed tables will not respond to HTTP requests.
+2. **Enable Automatic APIs**: Ensure your GraphQL schema includes the `@export` directive for the table.
+3. **Access REST Endpoints**: Use the standard endpoints for your table (Note: Paths are case-sensitive).
+4. **Use Automatic WebSockets**: Connect to `wss://your-harper-instance/{TableName}` to receive events whenever updates are made to that table. This is the easiest way to add real-time capabilities. (Use `ws://` for local development without SSL). For more complex needs, see [Real-time Apps](real-time-apps.md).
+5. **Apply Filtering and Querying**: Use query parameters with `GET /{TableName}/` and `DELETE /{TableName}/`. See the [Querying REST APIs](querying-rest-apis.md) skill for advanced details.
+6. **Customize if Needed**: If the automatic APIs don't meet your requirements, [customize the resources](./custom-resources.md).
+
+#### Examples
+
+##### Schema Configuration
+
+```graphql
+type MyTable @table @export {
+	id: ID @primaryKey
+	name: String
+}
+```
+
+##### Common REST Operations
+
+- **List Records**: `GET /MyTable/`
+- **Create Record**: `POST /MyTable/`
+- **Update Record**: `PATCH /MyTable/{id}`
 
 ### 2.2 Querying REST APIs
 
-How to use filters, operators, sorting, and pagination in REST requests.
+Instructions for the agent to follow when querying Harper's REST APIs.
 
-#### Query Parameters
+#### When to Use
 
-- `limit(count)` or `limit(offset, count)`: Number of records to return and optional skip. Example: `?limit(10)`, `?limit(10, 20)`.
-- `sort(+field1, -field2)`: Fields to sort by. Use `+` for ascending and `-` for descending. Example: `?sort(+name)`, `?sort(-price, +name)`.
-- `select(field1, field2)`: Specific fields to return. Example: `?select(id, name)`.
-- `filter`: Advanced filtering using comparison operators and logic.
-  - Operators: `gt`, `ge`, `lt`, `le`, `ne`. Example: `?price=gt=100`.
-  - Logic: `&` (AND), `|` (OR), `()` (grouping). Example: `?(category=electronics|category=books)&price=lt=500`.
+Use this skill when you need to perform advanced data retrieval (filtering, sorting, pagination, joins) using Harper's automatic REST endpoints.
+
+#### How It Works
+
+1. **Basic Filtering**: Use attribute names as query parameters: `GET /Table/?key=value`.
+2. **Use Comparison Operators**: Append operators like `gt`, `ge`, `lt`, `le`, `ne` using FIQL-style syntax: `GET /Table/?price=gt=100`.
+3. **Apply Logic and Grouping**: Use `&` for AND, `|` for OR, and `()` for grouping: `GET /Table/?(rating=5|featured=true)&price=lt=50`.
+4. **Select Specific Fields**: Use `select()` to limit returned attributes: `GET /Table/?select(name,price)`.
+5. **Paginate Results**: Use `limit(count)` or `limit(offset, count)` to set the number of records to return and skip.
+   - Example (first 10): `GET /Table/?limit(10)`
+   - Example (skip 20, return 10): `GET /Table/?limit(20, 10)`
+6. **Sort Results**: Use `sort()` with `+` (asc) or `-` (desc) before the field name. Avoid `sort=field` format.
+   - Example (asc): `GET /Table/?sort(+name)`
+   - Example (desc): `GET /Table/?sort(-price)`
+   - Example (combined): `GET /Table/?sort(-price,+name)`
+7. **Query Relationships**: Use dot syntax for tables linked with `@relationship`: `GET /Book/?author.name=Harper`.
 
 ### 2.3 Real-time Applications
 
-Implementing WebSockets and Pub/Sub for live data updates.
+Instructions for the agent to follow when building real-time applications in Harper.
 
 #### When to Use
 
-Use this for applications that require live updates, such as chat apps, live dashboards, or collaborative tools.
+Use this skill when you need to stream live updates to clients, implement chat features, or provide real-time data synchronization between the database and a frontend.
 
 #### How It Works
 
-1. **WebSocket Connection**: Connect to the Harper WebSocket endpoint. Use `wss://` for secure connections over HTTPS, or `ws://` for local development.
-2. **Subscribing**: Subscribe to table updates or specific records.
-3. **Pub/Sub**: Use the internal bus to publish and subscribe to custom events.
+1. **Check Automatic WebSockets**: If you only need to stream table changes, use [Automatic APIs](automatic-apis.md) which provide a WebSocket endpoint for every `@export`ed table.
+2. **Implement `connect` in a Resource**: For custom bi-directional logic, implement the `connect` method.
+3. **Use Pub/Sub**: Use `tables.TableName.subscribe(query)` to listen for specific data changes and stream them to the client.
+4. **Handle SSE**: Ensure your `connect` method gracefully handles cases where `incomingMessages` is null (Server-Sent Events).
+5. **Connect from Client**: Use standard WebSockets (`new WebSocket('wss://...')`) to connect to your resource endpoint. Ensure you use the appropriate scheme (`ws://` for HTTP, `wss://` for HTTPS).
+
+#### Examples
+
+##### Bi-directional WebSocket Resource
+
+```typescript
+import { Resource, tables } from 'harper';
+
+export class MySocket extends Resource {
+	async *connect(target, incomingMessages) {
+		// Subscribe to table changes
+		const subscription = await tables.MyTable.subscribe(target);
+		if (!incomingMessages) {
+			return subscription; // SSE mode
+		}
+
+		// Handle incoming client messages
+		for await (let message of incomingMessages) {
+			yield { received: message };
+		}
+	}
+}
+```
 
 ### 2.4 Checking Authentication
 
-How to use sessions to verify user identity and roles.
+Instructions for the agent to follow when handling authentication and sessions.
 
 #### When to Use
 
-Use this to secure your application by ensuring that only authorized users can access certain resources or perform specific actions.
+Use this skill when you need to implement sign-in/sign-out functionality, protect specific resource endpoints, or identify the currently logged-in user in a Harper application.
 
 #### How It Works
 
-1. **Session Handling**: Access the session object from the request context.
-2. **Identity Verification**: Check for the presence of a user ID or token.
-3. **Role Checks**: Verify if the user has the required roles for the action.
+1. **Configure Harper for Sessions**: Ensure `harper-config.yaml` has sessions enabled and local auto-authorization disabled for testing:
+   ```yaml
+   authentication:
+     authorizeLocal: false
+     enableSessions: true
+   ```
+2. **Implement Sign In**: Use `this.getContext().login(username, password)` to create a session:
+   ```typescript
+   async post(_target, data) {
+    const context = this.getContext();
+    try {
+      await context.login(data.username, data.password);
+    } catch {
+      return new Response('Invalid credentials', { status: 403 });
+    }
+    return new Response('Logged in', { status: 200 });
+   }
+   ```
+3. **Identify Current User**: Use `this.getCurrentUser()` to access session data:
+   ```typescript
+   async get() {
+     const user = this.getCurrentUser?.();
+     if (!user) return new Response(null, { status: 401 });
+     return { username: user.username, role: user.role };
+   }
+   ```
+4. **Implement Sign Out**: Use `this.getContext().logout()` or delete the session from context:
+   ```typescript
+   async post() {
+     const context = this.getContext();
+     await context.session?.delete?.(context.session.id);
+     return new Response('Logged out', { status: 200 });
+   }
+   ```
+5. **Protect Routes**: In your Resource, use `allowRead()`, `allowUpdate()`, etc., to enforce authorization logic based on `this.getCurrentUser()`. For privileged actions, verify `user.role.permission.super_user`.
 
----
+#### Examples
+
+##### Sign In Implementation
+
+```typescript
+async post(_target, data) {
+  const context = this.getContext();
+  try {
+    await context.login(data.username, data.password);
+  } catch {
+    return new Response('Invalid credentials', { status: 403 });
+  }
+  return new Response('Logged in', { status: 200 });
+}
+```
+
+##### Identify Current User
+
+```typescript
+async get() {
+  const user = this.getCurrentUser?.();
+  if (!user) return new Response(null, { status: 401 });
+  return { username: user.username, role: user.role };
+}
+```
+
+##### Sign Out Implementation
+
+```typescript
+async post() {
+  const context = this.getContext();
+  await context.session?.delete?.(context.session.id);
+  return new Response('Logged out', { status: 200 });
+}
+```
+
+#### Status code conventions used here
+
+- 200: Successful operation. For `GET /me`, a `200` with empty body means “not signed in”.
+- 400: Missing required fields (e.g., username/password on sign-in).
+- 401: No current session for an action that requires one (e.g., sign out when not signed in).
+- 403: Authenticated but not authorized (bad credentials on login attempt, or insufficient privileges).
+
+#### Client considerations
+
+- Sessions are cookie-based; the server handles setting and reading the cookie via Harper. If you make cross-origin requests, ensure the appropriate `credentials` mode and CORS settings.
+- If developing locally, double-check the server config still has `authentication.authorizeLocal: false` to avoid accidental superuser bypass.
+
+#### Token-based auth (JWT + refresh token) for non-browser clients
+
+Cookie-backed sessions are great for browser flows. For CLI tools, mobile apps, or other non-browser clients, it’s often easier to use **explicit tokens**:
+
+- **JWT (`operation_token`)**: short-lived bearer token used to authorize API requests.
+- **Refresh token (`refresh_token`)**: longer-lived token used to mint a new JWT when it expires.
+
+This project includes two Resource patterns for that flow:
+
+##### Issuing tokens: `IssueTokens`
+
+**Description / use case:** Generate `{ refreshToken, jwt }` either:
+
+- with an existing Authorization token (either Basic Auth or a JWT) and you want to issue new tokens, or
+- from an explicit `{ username, password }` payload (useful for direct “login” from a CLI/mobile client).
+
+```javascript
+export class IssueTokens extends Resource {
+	static loadAsInstance = false;
+
+	async get(target) {
+		const { refresh_token: refreshToken, operation_token: jwt } =
+			await databases.system.hdb_user.operation(
+				{ operation: 'create_authentication_tokens' },
+				this.getContext(),
+			);
+		return { refreshToken, jwt };
+	}
+
+	async post(target, data) {
+		if (!data.username || !data.password) {
+			throw new Error('username and password are required');
+		}
+
+		const { refresh_token: refreshToken, operation_token: jwt } =
+			await databases.system.hdb_user.operation({
+				operation: 'create_authentication_tokens',
+				username: data.username,
+				password: data.password,
+			});
+		return { refreshToken, jwt };
+	}
+}
+```
+
+**Recommended documentation notes to include:**
+
+- `GET` variant: intended for “I already have an Authorization token, give me new tokens”.
+- `POST` variant: intended for “I have credentials, give me tokens”.
+- Response shape:
+  - `refreshToken`: store securely (long-lived).
+  - `jwt`: attach to requests (short-lived).
+
+##### Refreshing a JWT: `RefreshJWT`
+
+**Description / use case:** When the JWT expires, the client uses the refresh token to get a new JWT without re-supplying username/password.
+
+```javascript
+export class RefreshJWT extends Resource {
+	static loadAsInstance = false;
+
+	async post(target, data) {
+		if (!data.refreshToken) {
+			throw new Error('refreshToken is required');
+		}
+
+		const { operation_token: jwt } = await databases.system.hdb_user.operation({
+			operation: 'refresh_operation_token',
+			refresh_token: data.refreshToken,
+		});
+		return { jwt };
+	}
+}
+```
+
+**Recommended documentation notes to include:**
+
+- Requires `refreshToken` in the request body.
+- Returns a new `{ jwt }`.
+- If refresh fails (expired/revoked), client must re-authenticate (e.g., call `IssueTokens.post` again).
+
+##### Suggested client flow (high-level)
+
+1. **Sign in (token flow)**
+   - POST /IssueTokens/ with a body of `{ "username": "your username", "password": "your password" }` or GET /IssueTokens/ with an existing Authorization token.
+   - Receive `{ jwt, refreshToken }` in the response
+2. **Call protected APIs**
+   - Send the JWT with each request in the Authorization header (as your auth mechanism expects)
+3. **JWT expires**
+   - POST /RefreshJWT/ with a body of `{ "refreshToken": "your refresh token" }`.
+   - Receive `{ jwt }` in the response and continue
+
+#### Quick checklist
+
+- [ ] Public endpoints explicitly `allowRead`/`allowCreate` as needed.
+- [ ] Sign-in uses `context.login` and handles 400/403 correctly.
+- [ ] Protected routes call `ensureSuperUser(this.getCurrentUser())` (or another role check) before doing work.
+- [ ] Sign-out verifies a session and deletes it.
+- [ ] `authentication.authorizeLocal` is `false` and `enableSessions` is `true` in Harper config.
+- [ ] If using tokens: `IssueTokens` issues `{ jwt, refreshToken }`, `RefreshJWT` refreshes `{ jwt }` with a `refreshToken`.
 
 ## 3. Logic & Extension
 
-**Impact: MEDIUM**
-
 ### 3.1 Custom Resources
 
-How to define custom REST endpoints using JavaScript or TypeScript.
-
-#### How It Works
-
-1. **Create Resource File**: Define your logic in a JS or TS file.
-2. **Define Resource Class**: Export a class extending `Resource` from `harper`.
-3. **Implement HTTP Methods**: Add methods like `get`, `post`, `put`, `patch`, or `delete` to handle corresponding requests.
-4. **Route Nesting and Naming**: You can control the URL structure by how you export your resources:
-   - **Direct Class Export**: `export class Foo extends Resource` creates endpoints at `/Foo/`. Class names are case-sensitive in the URL.
-   - **Nested Objects**: `export const Bar = { Foo };` creates endpoints at `/Bar/Foo/`.
-   - **Lowercase and Hyphens**: Use object keys to define custom paths: `export const bar = { 'foo-baz': Foo };` exposes endpoints at `/bar/foo-baz/`.
-5. **Registration**: Ensure the resource is correctly registered in your application configuration.
-
-### 3.2 Extending Table Resources
-
-Adding custom logic to automatically generated table resources.
-
-#### How It Works
-
-1. **Define Extension**: Create a resource file that targets an existing table.
-2. **Intercept Requests**: Use handlers to add custom validation or data transformation.
-3. **No `@export`**: If extending, remember not to `@export` the table in the schema.
-
-### 3.3 Programmatic Table Requests
-
-How to use filters, operators, sorting, and pagination in programmatic table requests.
-
-#### Usage
-
-When writing custom resources, use the internal API to query tables with full support for advanced filtering and sorting.
-
-### 3.4 TypeScript Type Stripping
-
-Using TypeScript directly without build tools via Node.js Type Stripping.
-
-#### Configuration
-
-Harper supports native TypeScript type stripping, allowing you to run `.ts` files directly. Ensure your environment is configured to take advantage of this for faster development cycles.
-
-### 3.5 Caching
-
-How caching is defined and implemented in Harper applications.
-
-#### Strategies
-
-- **In-memory**: For fast access to frequently used data.
-- **Distributed**: For scaling across multiple nodes in Harper Fabric.
-
----
-
-## 4. Infrastructure & Ops
-
-**Impact: MEDIUM**
-
-### 4.1 Creating Harper Applications
-
-The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command initializes a project with a standard folder structure, essential configuration files, and basic schema definitions.
+Instructions for the agent to follow when creating custom resources in Harper.
 
 #### When to Use
 
-Use this command when starting a new Harper application or adding a new Harper microservice to an existing architecture.
-
-#### Commands
-
-Initialize a project using your preferred package manager:
-
-**NPM**
-
-```bash
-npm create harper@latest
-```
-
-**PNPM**
-
-```bash
-pnpm create harper@latest
-```
-
-**Bun**
-
-```bash
-bun create harper@latest
-```
-
-### 4.2 Creating a Fabric Account and Cluster
-
-Follow these steps to set up your Harper Fabric environment for deployment.
+Use this skill when the automatic CRUD operations provided by `@table @export` are insufficient, and you need custom logic, third-party API integration, or specialized data handling for your REST endpoints.
 
 #### How It Works
 
-1. **Sign Up/In**: Go to [https://fabric.harper.fast/](https://fabric.harper.fast/) and sign up or sign in.
-2. **Create an Organization**: Create an organization (org) to manage your projects.
-3. **Create a Cluster**: Create a new cluster. This can be on the free tier, no credit card required.
-4. **Set Credentials**: During setup, set the cluster username and password to finish configuring it.
-5. **Get Application URL**: Navigate to the **Config** tab and copy the **Application URL**.
-6. **Configure Environment**: Update your `.env` file or GitHub Actions secrets with these cluster-specific credentials:
-   ```bash
-   CLI_TARGET_USERNAME='YOUR_CLUSTER_USERNAME'
-   CLI_TARGET_PASSWORD='YOUR_CLUSTER_PASSWORD'
-   CLI_TARGET='YOUR_CLUSTER_URL'
+1. **Check if a Custom Resource is Necessary**: Verify if [Automatic APIs](./automatic-apis.md) or [Extending Tables](./extending-tables.md) can satisfy the requirement first.
+2. **Create the Resource File**: Create a `.ts` or `.js` file in the directory specified by `jsResource` in `config.yaml` (typically `resources/`).
+3. **Define the Resource Class**: Export a class extending `Resource` from `harper`:
+
+   ```typescript
+   import { type RequestTargetOrId, Resource } from 'harper';
+
+   export class MyResource extends Resource {
+   	async get(target?: RequestTargetOrId) {
+   		return { message: 'Hello from custom GET!' };
+   	}
+   }
    ```
 
-### 4.3 Deploying to Harper Fabric
+4. **Implement HTTP Methods**: Add methods like `get`, `post`, `put`, `patch`, or `delete` to handle corresponding requests.
+5. **Route Nesting and Naming**: You can control the URL structure by how you export your resources:
+   - **Direct Class Export**: `export class Foo extends Resource` creates endpoints at `/Foo/`. Class names are case-sensitive in the URL.
+   - **Nested Objects**: `export const Bar = { Foo };` creates endpoints at `/Bar/Foo/`.
+   - **Lowercase and Hyphens**: Use object keys to define custom paths: `export const bar = { 'foo-baz': Foo };` exposes endpoints at `/bar/foo-baz/`.
+6. **Access Tables (Optional)**: Import and use the `tables` object to interact with your data:
+   ```typescript
+   import { tables } from 'harper';
+   // ... inside a method
+   const results = await tables.MyTable.list();
+   ```
+7. **Configure Loading**: Ensure `config.yaml` points to your resource files (e.g., `jsResource: { files: 'resources/*.ts' }`).
 
-Globally scaling your Harper application.
+### 3.2 Extending Tables
 
-#### Benefits
+Instructions for the agent to follow when extending table resources in Harper.
 
-- **Global Distribution**: Low latency for users everywhere.
-- **Automatic Sync**: Data is synced across the fabric automatically.
-- **Free Tier**: Start for free and scale as you grow.
+#### When to Use
+
+Use this skill when you need to add custom validation, side effects (like webhooks), data transformation, or custom access control to the standard CRUD operations of a Harper table.
 
 #### How It Works
 
-1. **Sign up**: Follow the [Creating a Fabric Account and Cluster](#42-creating-a-fabric-account-and-cluster) steps to create a Harper Fabric account, organization, and cluster.
+1. **Define the Table in GraphQL**: In your `.graphql` schema, define the table using the `@table` directive. **Do not** use `@export` if you plan to extend it.
+   ```graphql
+   type MyTable @table {
+   	id: ID @primaryKey
+   	name: String
+   }
+   ```
+2. **Create the Extension File**: Create a `.ts` file in your `resources/` directory.
+3. **Extend the Table Resource**: Export a class that extends `tables.YourTableName`:
+
+   ```typescript
+   import { type RequestTargetOrId, tables } from 'harper';
+
+   export class MyTable extends tables.MyTable {
+   	async post(target: RequestTargetOrId, record: any) {
+   		// Custom logic here
+   		if (!record.name) {
+   			throw new Error('Name required');
+   		}
+   		return super.post(target, record);
+   	}
+   }
+   ```
+
+4. **Override Methods**: Override `get`, `post`, `put`, `patch`, or `delete` as needed. Always call `super[method]` to maintain default Harper functionality unless you intend to replace it entirely.
+5. **Implement Logic**: Use overrides for validation, side effects, or transforming data before/after database operations.
+
+### 3.3 Programmatic Table Requests
+
+Instructions for the agent to follow when interacting with Harper tables via code.
+
+#### When to Use
+
+Use this skill when you need to perform database operations (CRUD, search, subscribe) from within Harper Resources or scripts.
+
+#### How It Works
+
+1. **Access the Table**: Use the global `tables` object followed by your table name (e.g., `tables.MyTable`).
+2. **Perform CRUD Operations**:
+   - **Get**: `await tables.MyTable.get(id)` for a single record or `await tables.MyTable.get({ conditions: [...] })` for multiple.
+   - **Create**: `await tables.MyTable.post(record)` (auto-generates ID) or `await tables.MyTable.put(id, record)`.
+   - **Update**: `await tables.MyTable.patch(id, partialRecord)` for partial updates.
+   - **Delete**: `await tables.MyTable.delete(id)`.
+3. **Use Updatable Records for Atomic Ops**: Call `update(id)` to get a reference, then use `addTo` or `subtractFrom` for atomic increments/decrements:
+   ```typescript
+   const stats = await tables.Stats.update('daily');
+   stats.addTo('viewCount', 1);
+   ```
+4. **Search and Stream**: Use `search(query)` for efficient streaming of large result sets:
+   ```typescript
+   for await (const record of tables.MyTable.search({ conditions: [...] })) {
+     // process record
+   }
+   ```
+   See the [Query Conditions](#query-conditions) section below for the full query object reference.
+5. **Real-time Subscriptions**: Use `subscribe(query)` to listen for changes:
+   ```typescript
+   for await (const event of tables.MyTable.subscribe(query)) {
+   	// handle event
+   }
+   ```
+6. **Publish Events**: Use `publish(id, message)` to trigger subscriptions without necessarily persisting data.
+
+#### Query Conditions
+
+When passing a query to `search()`, `get()`, or `subscribe()`, use a query object with a `conditions` array.
+
+##### Condition Object Shape
+
+| Property     | Description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `attribute`  | Field name, or array of field names to traverse a relationship (e.g., `['brand', 'name']`) |
+| `value`      | The value to compare against                                                               |
+| `comparator` | One of the comparator strings below (default: `equals`)                                    |
+| `operator`   | `and` (default) or `or` — applies to a nested `conditions` block                           |
+| `conditions` | Nested array of condition objects for complex AND/OR logic                                 |
+
+##### Comparator Values
+
+Use these exact strings — incorrect comparator names will silently fail or error:
+
+| Comparator           | Meaning                                                    |
+| -------------------- | ---------------------------------------------------------- |
+| `equals`             | Exact match (default)                                      |
+| `not_equal`          | Not equal                                                  |
+| `greater_than`       | `>`                                                        |
+| `greater_than_equal` | `>=`                                                       |
+| `less_than`          | `<`                                                        |
+| `less_than_equal`    | `<=`                                                       |
+| `starts_with`        | String starts with value                                   |
+| `contains`           | String contains value                                      |
+| `ends_with`          | String ends with value                                     |
+| `between`            | Value is between two bounds (pass `value` as `[min, max]`) |
+
+##### Query Object Parameters
+
+| Property     | Description                                                                          |
+| ------------ | ------------------------------------------------------------------------------------ |
+| `conditions` | Array of condition objects                                                           |
+| `limit`      | Maximum number of records to return                                                  |
+| `offset`     | Number of records to skip (for pagination)                                           |
+| `select`     | Array of attribute names to return; supports `$id` and `$updatedtime`                |
+| `sort`       | Object with `attribute`, `descending` (bool), and optional `next` for secondary sort |
+
+##### Examples
+
+**Simple filter:**
+
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [{ attribute: 'price', comparator: 'less_than', value: 100 }],
+  limit: 20,
+})) { ... }
+```
+
+**AND + nested OR:**
+
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [
+    { attribute: 'price', comparator: 'less_than', value: 100 },
+    {
+      operator: 'or',
+      conditions: [
+        { attribute: 'rating', comparator: 'greater_than', value: 4 },
+        { attribute: 'featured', value: true },
+      ],
+    },
+  ],
+})) { ... }
+```
+
+**Relationship traversal:**
+
+```javascript
+for await (const record of tables.Book.search({
+  conditions: [{ attribute: ['brand', 'name'], comparator: 'equals', value: 'Harper' }],
+})) { ... }
+```
+
+**Sort and paginate:**
+
+```javascript
+for await (const record of tables.Product.search({
+  conditions: [{ attribute: 'inStock', value: true }],
+  sort: { attribute: 'price', descending: false },
+  limit: 10,
+  offset: 20,
+})) { ... }
+```
+
+#### Cautions
+
+Be very careful when performing updates and deletions! You may be dealing with live production data. The wrong request to delete, without approval from a human, could be devastating to a business. Always use the proper approval process.
+
+### 3.4 TypeScript Type Stripping
+
+Instructions for the agent to follow when using TypeScript in Harper.
+
+#### When to Use
+
+Use this skill when you want to write Harper Resources in TypeScript and have them execute directly in Node.js without an intermediate build or compilation step.
+
+#### How It Works
+
+1. **Verify Node.js Version**: Ensure you are using Node.js v22.6.0 or higher.
+2. **Name Files with `.ts`**: Create your resource files in the `resources/` directory with a `.ts` extension.
+3. **Use TypeScript Syntax**: Write your resource classes using standard TypeScript (interfaces, types, etc.).
+   ```typescript
+   import { Resource } from 'harper';
+   export class MyResource extends Resource {
+   	async get(): Promise<{ message: string }> {
+   		return { message: 'Running TS directly!' };
+   	}
+   }
+   ```
+4. **Use Explicit Extensions in Imports**: When importing other local modules, include the `.ts` extension: `import { helper } from './helper.ts'`.
+5. **Configure `config.yaml`**: Ensure `jsResource` points to your `.ts` files:
+   ```yaml
+   jsResource:
+     files: 'resources/*.ts'
+   ```
+
+### 3.5 Caching
+
+Instructions for the agent to follow when implementing caching in Harper.
+
+#### When to Use
+
+Use this skill when you need high-performance, low-latency storage for data from external sources. It's ideal for reducing API calls to third-party services, preventing cache stampedes, and making external data queryable as if it were native Harper tables.
+
+#### How It Works
+
+1. **Configure a Cache Table**: Define a table in your `schema.graphql` with an `expiration` (in seconds).
+2. **Define an External Source**: Create a Resource class that fetches the data from your source.
+3. **Attach Source to Table**: Use `sourcedFrom` to link your resource to the table.
+4. **Implement Active Caching (Optional)**: Use `subscribe()` for proactive updates. See [Real-Time Apps](real-time-apps.md).
+5. **Implement Write-Through Caching (Optional)**: Define `put` or `post` in your resource to propagate updates upstream.
+
+#### Examples
+
+##### Schema Configuration
+
+```graphql
+type MyCache @table(expiration: 3600) @export {
+	id: ID @primaryKey
+}
+```
+
+##### Resource Implementation
+
+```js
+import { Resource, tables } from 'harper';
+
+export class ThirdPartyAPI extends Resource {
+	async get() {
+		const id = this.getId();
+		const response = await fetch(`https://api.example.com/items/${id}`);
+		if (!response.ok) {
+			throw new Error('Source fetch failed');
+		}
+		return await response.json();
+	}
+}
+
+// Attach source to table
+tables.MyCache.sourcedFrom(ThirdPartyAPI);
+```
+
+## 4. Infrastructure & Ops
+
+### 4.1 Deploying to Harper Fabric
+
+Instructions for the agent to follow when deploying to Harper Fabric.
+
+#### When to Use
+
+Use this skill when you are ready to move your Harper application from local development to a cloud-hosted environment.
+
+#### How It Works
+
+1. **Sign up**: Follow the [creating-a-fabric-account-and-cluster](creating-a-fabric-account-and-cluster.md) rule to create a Harper Fabric account, organization, and cluster.
 2. **Configure Environment**: Add your cluster credentials and cluster application URL to `.env`:
    ```bash
    CLI_TARGET_USERNAME='YOUR_CLUSTER_USERNAME'
@@ -422,7 +892,7 @@ Globally scaling your Harper application.
 
 If your application was not created with `npm create harper`, you'll need to manually configure the deployment scripts and CI/CD workflow.
 
-#### 1. Update `package.json`
+##### 1. Update `package.json`
 
 Add the following scripts and dependencies to your `package.json`:
 
@@ -439,7 +909,7 @@ Add the following scripts and dependencies to your `package.json`:
 }
 ```
 
-#### Why split the scripts?
+###### Why split the scripts?
 
 The `deploy` script is separated from `deploy:component` to ensure environment variables from your `.env` file are properly loaded and passed to the Harper CLI.
 
@@ -448,7 +918,7 @@ The `deploy` script is separated from `deploy:component` to ensure environment v
 
 By using `dotenv -- npm run deploy:component`, the environment variables are correctly set in the shell session before `harper deploy_component` is called, allowing it to authenticate with your cluster.
 
-#### 2. Configure GitHub Actions
+##### 2. Configure GitHub Actions
 
 Create a `.github/workflows/deploy.yaml` file with the following content:
 
@@ -456,9 +926,9 @@ Create a `.github/workflows/deploy.yaml` file with the following content:
 name: Deploy to Harper Fabric
 on:
   workflow_dispatch:
-#  push:
-#    branches:
-#      - main
+###  push:
+###    branches:
+###      - main
 concurrency:
   group: main
   cancel-in-progress: false
@@ -467,12 +937,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           cache: 'npm'
-          node-version: '20'
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: Run unit tests
@@ -487,20 +960,140 @@ jobs:
           CLI_TARGET_PASSWORD: ${{ secrets.CLI_TARGET_PASSWORD }}
 ```
 
-Be sure to set the following repository secrets in your GitHub repository:
+Be sure to set the following repository secrets in your GitHub repository's /settings/secrets/actions:
 
 - `CLI_TARGET`
 - `CLI_TARGET_USERNAME`
 - `CLI_TARGET_PASSWORD`
 
+### 4.2 Creating a Harper Fabric Account and Cluster
+
+Follow these steps to set up your Harper Fabric environment for deployment.
+
+#### How It Works
+
+1. **Sign Up/In**: Go to [https://fabric.harper.fast/](https://fabric.harper.fast/) and sign up or sign in.
+2. **Create an Organization**: Create an organization (org) to manage your projects.
+3. **Create a Cluster**: Create a new cluster. This can be on the free tier, no credit card required.
+4. **Set Credentials**: During setup, set the cluster username and password to finish configuring it.
+5. **Get Application URL**: Navigate to the **Config** tab and copy the **Application URL**.
+6. **Configure Environment**: Update your `.env` file or GitHub Actions secrets with cluster-specific credentials.
+7. **Next Steps**: See the [deploying-to-harper-fabric](deploying-to-harper-fabric.md) rule for detailed instructions on deploying your application successfully.
+
+#### Examples
+
+##### Environment Configuration
+
+```bash
+CLI_TARGET_USERNAME='YOUR_CLUSTER_USERNAME'
+CLI_TARGET_PASSWORD='YOUR_CLUSTER_PASSWORD'
+CLI_TARGET='YOUR_CLUSTER_URL'
+```
+
+### 4.3 Creating Harper Applications
+
+The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command initializes a project with a standard folder structure, essential configuration files, and basic schema definitions.
+
+#### When to Use
+
+Use this command when starting a new Harper application or adding a new Harper microservice to an existing architecture.
+
+#### Commands
+
+Initialize a project using your preferred package manager:
+
+##### NPM
+
+```bash
+npm create harper@latest
+```
+
+##### PNPM
+
+```bash
+pnpm create harper@latest
+```
+
+##### Bun
+
+```bash
+bun create harper@latest
+```
+
+#### Options
+
+You can specify the project name and template directly:
+
+```bash
+npm create harper@latest my-app --template default
+```
+
+#### Next Steps
+
+1. **Configure Environment**: Set up your `.env` file with local or cloud credentials.
+2. **Define Schema**: Modify `schema.graphql` to fit your application's data model.
+3. **Start Development**: Run `npm run dev` to start the local Harper instance.
+4. **Deploy**: Use `npm run deploy` to push your application to Harper Fabric.
+
 ### 4.4 Serving Web Content
 
-Two ways to serve web content from a Harper application.
+Instructions for the agent to follow when serving web content from Harper.
 
-#### Methods
+#### When to Use
 
-1. **Static Serving**: Serve HTML, CSS, and JS files directly. If using the Vite plugin for development, ensure Harper is running (e.g., `harper run .`) to allow for Hot Module Replacement (HMR).
-2. **Dynamic Rendering**: Use custom resources to render content on the fly.
+Use this skill when you need to serve a frontend (HTML, CSS, JS, or a React app) directly from your Harper instance.
+
+#### How It Works
+
+1. **Choose a Method**: Decide between the simple Static Plugin or the integrated Vite Plugin.
+2. **Option A: Static Plugin (Simple)**:
+   - Add to `config.yaml`:
+     ```yaml
+     static:
+       files: 'web/*'
+     ```
+   - Place files in a `web/` folder in the project root.
+   - Files are served at the root URL (e.g., `http://localhost:9926/index.html`).
+3. **Option B: Vite Plugin (Advanced/Development)**:
+   - Add to `config.yaml`:
+     ```yaml
+     '@harperfast/vite-plugin':
+       package: '@harperfast/vite-plugin'
+     ```
+   - Ensure `vite.config.ts` and `index.html` are in the project root.
+
+   ```javascript
+   import vue from '@vitejs/plugin-vue';
+   import path from 'node:path';
+   import { defineConfig } from 'vite';
+
+   // https://vite.dev/config/
+   export default defineConfig({
+   	plugins: [vue()],
+   	resolve: {
+   		alias: {
+   			'@': path.resolve(import.meta.dirname, './src'),
+   		},
+   	},
+   	build: {
+   		outDir: 'web',
+   		emptyOutDir: true,
+   		rolldownOptions: {
+   			external: ['**/*.test.*', '**/*.spec.*'],
+   		},
+   	},
+   });
+   ```
+
+   - Install dependencies: `npm install --save-dev vite @harperfast/vite-plugin`.
+   - Then `harper run .` will start up Harper and Vite with HMR. Vite does _not_ need to be executed separately.
+
+4. **Deploy for Production**: For Vite apps, use a build script to generate static files into a `web/` folder and deploy them using the static handler pattern. For example, these scripts in a package.json can perform the necessary steps:
+   ```json
+   "build": "vite build",
+   "deploy": "rm -Rf deploy && npm run build && mkdir deploy && mv web deploy/ && cp -R deploy-template/* deploy/ && cp -R schemas resources deploy/ && (cd deploy && harper deploy_component . project=web restart=rolling replicated=true) && rm -Rf deploy",
+   ```
+   Then in production, the "Static Plugin" option will performantly and securely serve your assets. `npm create harper@latest` scaffolds all of this for you.
 
 ### 4.5 Logging Best Practices
 

--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -41,7 +41,19 @@ rules:
     category: schema
     priority: 1
     order: 4
-    mode: synthesized
+    mode: generate
+    sources:
+      - path: reference/v5/database/schema.md
+        section: 'Vector Indexing'
+        role: primary
+    must_cover:
+      - '@indexed(type: "HNSW")'
+      - 'sort'
+      - 'target'
+      - 'cosine'
+      - 'efConstruction'
+    cross_links:
+      - adding-tables-with-schemas
 
   - rule: using-blob-datatype
     description: How to use the Blob data type for efficient binary storage in Harper.

--- a/harper-best-practices/rules/vector-indexing.md
+++ b/harper-best-practices/rules/vector-indexing.md
@@ -2,160 +2,96 @@
 name: vector-indexing
 description: How to enable and query vector indexes for similarity search in Harper.
 metadata:
-  mode: synthesized
+  mode: generate
+  sources:
+    - reference/v5/database/schema.md#Vector Indexing
+  sourceCommit: e8fc9e51c7c04637b8ec02d073eed42d495034f1
+  inputHash: 9c47b18c8795e403
 ---
 
 # Vector Indexing
 
-Instructions for the agent to follow when implementing vector search in Harper.
+Instructions for the agent to follow when enabling and querying vector indexes for similarity search in Harper using the HNSW algorithm.
 
 ## When to Use
 
-Use this skill when you need to perform similarity searches on high-dimensional data, such as AI embeddings for semantic search, recommendations, or image retrieval.
+Apply this rule when adding a vector index to a Harper table schema to support approximate nearest-neighbor (similarity) search on high-dimensional float arrays. Use it whenever a query requires ranking results by vector similarity, optionally combined with filter conditions.
 
 ## How It Works
 
-1. **Enable Vector Indexing**: In your GraphQL schema, add `@indexed(type: "HNSW")` to a numeric array field:
+1. **Define the table schema with a vector index**: Add `@indexed(type: "HNSW")` to a `[Float]` attribute on a `@table` type. See [adding-tables-with-schemas](adding-tables-with-schemas.md) for general schema setup.
+
    ```graphql
-   type Product @table {
-   	id: ID @primaryKey
+   type Document @table {
+   	id: Long @primaryKey
    	textEmbeddings: [Float] @indexed(type: "HNSW")
    }
    ```
-2. **Configure Index Options (Optional)**: Fine-tune the index with parameters like `distance` (`cosine` or `euclidean`), `M`, and `efConstruction`.
-3. **Query with Vector Search**: Use `tables.Table.search()` with a `sort` object containing the `target` vector:
+
+2. **Query by nearest neighbors**: Call `.search()` with a `sort` parameter specifying the indexed `attribute` and a `target` vector. The `target` is the query vector to compare against.
+
    ```javascript
-   const results = await tables.Product.search({
-     select: ['name', '$distance'],
-     sort: {
-       attribute: 'textEmbeddings',
-       target: [0.1, 0.2, ...], // query vector
-     },
-     limit: 5,
+   let results = Document.search({
+   	sort: { attribute: 'textEmbeddings', target: searchVector },
+   	limit: 5,
    });
    ```
-4. **Filter by Distance**: Use `conditions` with a `target` vector and a `comparator` (e.g., `lt`) to return results within a similarity threshold:
+
+3. **Combine with filter conditions**: Add a `conditions` array alongside `sort` to filter results before ranking by similarity.
+
    ```javascript
-   const results = await tables.Product.search({
-   	conditions: {
-   		attribute: 'textEmbeddings',
-   		comparator: 'lt',
-   		value: 0.1,
-   		target: searchVector,
-   	},
+   let results = Document.search({
+   	conditions: [{ attribute: 'price', comparator: 'lt', value: 50 }],
+   	sort: { attribute: 'textEmbeddings', target: searchVector },
+   	limit: 5,
    });
    ```
-5. **Generate Embeddings**: Use external services (OpenAI, Ollama) to generate the numeric vectors before storing or searching them in Harper.
 
-```typescript
-import OpenAI from 'openai';
-import ollama from 'ollama';
+4. **Tune HNSW parameters**: Pass additional parameters directly in the `@indexed` directive to control index quality and performance.
 
-const { Product } = tables;
-const openai = new OpenAI();
-// the name of the OpenAI embedding model
-const OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
-
-// the name of the Ollama embedding model
-const OLLAMA_EMBEDDING_MODEL = 'llama3';
-
-const SIMILARITY_THRESHOLD = 0.5;
-
-export class ProductSearch extends Resource {
-	// based on env variable we choose the appropriate embedding generator
-	generateEmbedding =
-		process.env.EMBEDDING_GENERATOR === 'ollama'
-			? this._generateOllamaEmbedding
-			: this._generateOpenAIEmbedding;
-
-	/**
-	 * Executes a search query using a generated text embedding and returns the matching products.
-	 *
-	 * @param {Object} data - The input data for the request.
-	 * @param {string} data.prompt - The prompt to generate the text embedding from.
-	 * @return {Promise<Array>} Returns a promise that resolves to an array of products matching the conditions,
-	 * including fields: name, description, price, and $distance.
-	 */
-	async post(data) {
-		const embedding = await this.generateEmbedding(data.prompt);
-
-		return await Product.search({
-			select: ['name', 'description', 'price', '$distance'],
-			conditions: {
-				attribute: 'textEmbeddings',
-				comparator: 'lt',
-				value: SIMILARITY_THRESHOLD,
-				target: embedding[0],
-			},
-			limit: 5,
-		});
-	}
-
-	/**
-	 * Generates an embedding using the Ollama API.
-	 *
-	 * @param {string} promptData - The input data for which the embedding is to be generated.
-	 * @return {Promise<number[][]>} A promise that resolves to the generated embedding as an array of numbers.
-	 */
-	async _generateOllamaEmbedding(promptData) {
-		const embedding = await ollama.embed({
-			model: OLLAMA_EMBEDDING_MODEL,
-			input: promptData,
-		});
-		return embedding?.embeddings;
-	}
-
-	/**
-	 * Generates OpenAI embeddings based on the given prompt data.
-	 *
-	 * @param {string} promptData - The input data used for generating the embedding.
-	 * @return {Promise<number[][]>} A promise that resolves to an array of embeddings, where each embedding is an array of floats.
-	 */
-	async _generateOpenAIEmbedding(promptData) {
-		const embedding = await openai.embeddings.create({
-			model: OPENAI_EMBEDDING_MODEL,
-			input: promptData,
-			encoding_format: 'float',
-		});
-
-		let embeddings = [];
-		embedding.data.forEach((embeddingData) => {
-			embeddings.push(embeddingData.embedding);
-		});
-
-		return embeddings;
-	}
-}
-```
+   | Parameter              | Default           | Description                                                                                         |
+   | ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------- |
+   | `distance`             | `"cosine"`        | Distance function: `"euclidean"` or `"cosine"` (negative cosine similarity)                         |
+   | `efConstruction`       | `100`             | Max nodes explored during index construction. Higher = better recall, lower = better performance    |
+   | `M`                    | `16`              | Preferred connections per graph layer. Higher = more space, better recall for high-dimensional data |
+   | `optimizeRouting`      | `0.5`             | Heuristic aggressiveness for omitting redundant connections (0 = off, 1 = most aggressive)          |
+   | `mL`                   | computed from `M` | Normalization factor for level generation                                                           |
+   | `efSearchConstruction` | `50`              | Max nodes explored during search                                                                    |
 
 ## Examples
 
-Sample request to the `ProductSearch` resource which prompts to find "shorts for the gym":
+Schema with default settings:
 
-```bash
-curl -X POST "http://localhost:9926/ProductSearch/" \
--H "Accept: application/json" \
--H "Content-Type: application/json" \
--H "Authorization: Basic <YOUR_AUTH>" \
--d '{"prompt": "shorts for the gym"}'
+```graphql
+type Document @table {
+	id: Long @primaryKey
+	textEmbeddings: [Float] @indexed(type: "HNSW")
+}
 ```
 
----
+Schema with custom parameters (euclidean distance, routing disabled, higher search recall):
 
-## When to Use Vector Indexing
+```graphql
+type Document @table {
+	id: Long @primaryKey
+	textEmbeddings: [Float]
+		@indexed(type: "HNSW", distance: "euclidean", optimizeRouting: 0, efSearchConstruction: 100)
+}
+```
 
-Vector indexing is ideal when:
+Filtered nearest-neighbor search:
 
-- Storing embedding vectors from ML models
-- Performing semantic or similarity-based search
-- Working with high-dimensional numeric data
-- Exact-match indexes are insufficient
+```javascript
+let results = Document.search({
+	conditions: [{ attribute: 'price', comparator: 'lt', value: 50 }],
+	sort: { attribute: 'textEmbeddings', target: searchVector },
+	limit: 5,
+});
+```
 
----
+## Notes
 
-## Summary
-
-- Vector indexing enables fast similarity search on numeric arrays
-- Defined using `@indexed(type: "HNSW")`
-- Queried using a target vector in search sorting
-- Tunable for performance and accuracy
+- The default `distance` function is `cosine`. Use `"euclidean"` when your vectors are not normalized or when Euclidean geometry better fits your use case.
+- Increasing `efConstruction` improves index recall at the cost of build performance.
+- `mL` is computed automatically from `M` unless explicitly overridden.
+- Always pair `sort` with a `limit` to bound the number of nearest-neighbor results returned.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.5.1",
 			"license": "Apache License 2.0",
 			"devDependencies": {
+				"@anthropic-ai/sdk": "^0.98.0",
 				"@commitlint/cli": "^20.4.1",
 				"@commitlint/config-conventional": "^20.4.1",
 				"@semantic-release/commit-analyzer": "^13.0.1",
@@ -74,6 +75,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.98.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+			"integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -93,6 +116,16 @@
 			"version": "7.28.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
 			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1469,6 +1502,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.3.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
@@ -2427,6 +2467,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"dev": true,
+			"license": "Unlicense"
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3095,6 +3142,20 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
@@ -6783,6 +6844,17 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/stream-combiner2": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -7141,6 +7213,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
 		"build": "node scripts/build.mjs",
 		"format": "oxfmt",
 		"format:check": "oxfmt --check",
+		"generate": "node scripts/generation/generate-rules.mjs",
 		"validate": "npm run format:check && npm run build && node scripts/validate-skills.mjs && node scripts/generation/validate-generated.mjs"
 	},
 	"devDependencies": {
+		"@anthropic-ai/sdk": "^0.98.0",
 		"@commitlint/cli": "^20.4.1",
 		"@commitlint/config-conventional": "^20.4.1",
 		"@semantic-release/commit-analyzer": "^13.0.1",

--- a/scripts/generation/generate-rules.mjs
+++ b/scripts/generation/generate-rules.mjs
@@ -1,0 +1,225 @@
+// Docs-driven rule generator.
+//
+// Reads the rules manifest, resolves each rule's sources from a local docs
+// build directory, and (re)writes rule bodies — via an LLM rewrite for
+// `mode: generate`, verbatim for `mode: direct`, and untouched for
+// `mode: synthesized`. Then reassembles AGENTS.md and formats the output.
+//
+// Offline-first: this never fetches docs over the network. It reads from a
+// local docs checkout that has been built (the plugin's flat-markdown lives
+// under `<docs>/build/`). In CI the workflow checks out + builds the docs
+// repo; locally, point at a sibling checkout.
+//
+// Usage:
+//   node scripts/generation/generate-rules.mjs [--docs-path <dir>] [--rule <slug>] [--force]
+//   npm run generate -- --docs-path ../documentation
+//
+// Flags:
+//   --docs-path <dir>  Path to the docs repo checkout (default: ../documentation,
+//                      or DOCS_PATH env). The build output is <docs-path>/build.
+//   --rule <slug>      Only (re)generate this one rule. Useful for local iteration.
+//   --force            Regenerate even if the input hash is unchanged.
+//
+// Environment:
+//   ANTHROPIC_API_KEY  Required for any rule in `mode: generate`.
+//   GENERATE_MODEL     Override the model (default claude-sonnet-4-6).
+//   DOCS_PATH          Default for --docs-path.
+//   DOCS_SHA           Docs commit SHA to record (default: git HEAD of the checkout).
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync, execSync } from 'node:child_process';
+import matter from 'gray-matter';
+
+import { loadManifest, SKILLS, sortedRules } from './lib/manifest.mjs';
+import { computeInputHash, resolveSources } from './lib/sources.mjs';
+import { generateRuleBody, generationModel } from './lib/llm.mjs';
+import { assembleAgentsMd, bodyOf, buildFrontmatter, composeRuleFile } from './lib/render.mjs';
+
+const AGENTS_LEAD =
+	'Guidelines for building scalable, secure, and performant applications on Harper. These practices cover everything from initial schema design to advanced deployment strategies.';
+
+function parseArgs(argv) {
+	const args = { docsPath: process.env.DOCS_PATH || '../documentation', rule: null, force: false };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--docs-path') args.docsPath = argv[++i];
+		else if (a === '--rule') args.rule = argv[++i];
+		else if (a === '--force') args.force = true;
+		else throw new Error(`Unknown argument: ${a}`);
+	}
+	return args;
+}
+
+function resolveDocsSha(docsRepoPath) {
+	if (process.env.DOCS_SHA) return process.env.DOCS_SHA;
+	try {
+		return execFileSync('git', ['-C', docsRepoPath, 'rev-parse', 'HEAD'], {
+			encoding: 'utf-8',
+		}).trim();
+	} catch {
+		return 'unknown';
+	}
+}
+
+async function exists(p) {
+	try {
+		await fs.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// Read the existing rule file's frontmatter metadata, if the file exists.
+async function readExistingMeta(filePath) {
+	if (!(await exists(filePath))) return null;
+	const raw = await fs.readFile(filePath, 'utf-8');
+	return matter(raw).data?.metadata ?? null;
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const docsRepoPath = path.resolve(args.docsPath);
+	const docsBuildDir = path.join(docsRepoPath, 'build');
+
+	if (!(await exists(docsBuildDir))) {
+		console.error(
+			`Docs build directory not found: ${docsBuildDir}\n` +
+				`Check out HarperFast/documentation and run \`npm ci && npm run build\` there,\n` +
+				`then re-run with --docs-path <that-checkout> (or set DOCS_PATH).`,
+		);
+		process.exit(1);
+	}
+
+	const docsSha = resolveDocsSha(docsRepoPath);
+	console.log(`Docs build: ${docsBuildDir}`);
+	console.log(`Docs SHA:   ${docsSha}`);
+
+	let changed = 0;
+	let skipped = 0;
+	let synthesized = 0;
+	let totalUsage = { input: 0, output: 0, cacheRead: 0 };
+
+	for (const skill of SKILLS) {
+		const manifest = await loadManifest(skill);
+		const rulesDir = path.join(process.cwd(), skill.dir, skill.rulesDir);
+		const rules = args.rule
+			? manifest.rules.filter((r) => r.rule === args.rule)
+			: sortedRules(manifest);
+
+		if (args.rule && rules.length === 0) {
+			console.error(`Rule "${args.rule}" not found in ${skill.manifestFile}`);
+			process.exit(1);
+		}
+
+		for (const entry of rules) {
+			const filePath = path.join(rulesDir, `${entry.rule}.md`);
+
+			if (entry.mode === 'synthesized') {
+				synthesized++;
+				continue;
+			}
+
+			// Resolve + hash sources.
+			let sourceContent;
+			try {
+				sourceContent = await resolveSources(docsBuildDir, entry.sources);
+			} catch (err) {
+				console.error(`✗ ${entry.rule}: failed to resolve sources — ${err.message}`);
+				process.exit(1);
+			}
+			const inputHash = computeInputHash(sourceContent);
+
+			// Skip if unchanged.
+			const existingMeta = await readExistingMeta(filePath);
+			const unchanged =
+				existingMeta && existingMeta.mode === entry.mode && existingMeta.inputHash === inputHash;
+			if (unchanged && !args.force) {
+				skipped++;
+				continue;
+			}
+
+			// Produce the body.
+			let body;
+			if (entry.mode === 'direct') {
+				body = sourceContent;
+			} else if (entry.mode === 'generate') {
+				const result = await generateRuleBody({
+					rule: entry.rule,
+					description: entry.description,
+					sourceContent,
+					mustCover: entry.must_cover,
+					crossLinks: entry.cross_links,
+				});
+				body = result.body;
+				totalUsage.input += result.usage.input_tokens ?? 0;
+				totalUsage.output += result.usage.output_tokens ?? 0;
+				totalUsage.cacheRead += result.usage.cache_read_input_tokens ?? 0;
+			} else {
+				console.error(`✗ ${entry.rule}: unknown mode "${entry.mode}"`);
+				process.exit(1);
+			}
+
+			const frontmatter = buildFrontmatter(entry, { sourceCommit: docsSha, inputHash });
+			await fs.writeFile(filePath, composeRuleFile(frontmatter, body), 'utf-8');
+			console.log(`✓ ${entry.rule} (${entry.mode})`);
+			changed++;
+		}
+
+		skill.__manifest = manifest;
+		skill.__rulesDir = rulesDir;
+	}
+
+	// Format the generated rule files first, so AGENTS.md is assembled from the
+	// final (formatted) rule bodies. This keeps the validator's round-trip check
+	// exact: it assembles from the same formatted bodies and re-runs oxfmt.
+	try {
+		execSync('npm run format', { stdio: 'inherit' });
+	} catch (err) {
+		console.warn(`Could not run formatter after generation: ${err.message}`);
+	}
+
+	// Reassemble AGENTS.md from the formatted rule bodies (skip on single-rule
+	// runs — AGENTS.md is regenerated on the next full run).
+	if (!args.rule) {
+		for (const skill of SKILLS) {
+			const manifest = skill.__manifest ?? (await loadManifest(skill));
+			const rulesDir = skill.__rulesDir ?? path.join(process.cwd(), skill.dir, skill.rulesDir);
+			const bodies = new Map();
+			for (const entry of manifest.rules) {
+				const raw = await fs.readFile(path.join(rulesDir, `${entry.rule}.md`), 'utf-8');
+				bodies.set(entry.rule, bodyOf(raw));
+			}
+			const agentsMd = assembleAgentsMd(manifest, (slug) => bodies.get(slug), {
+				lead: AGENTS_LEAD,
+			});
+			const agentsPath = path.join(process.cwd(), skill.dir, skill.agentsFile);
+			await fs.writeFile(agentsPath, agentsMd, 'utf-8');
+			// Format AGENTS.md itself so the committed file equals
+			// oxfmt(assemble(formatted bodies)) — the exact value the validator
+			// recomputes for its round-trip equality check.
+			try {
+				execSync(`npx oxfmt ${JSON.stringify(agentsPath)}`, { stdio: 'inherit' });
+			} catch (err) {
+				console.warn(`Could not format ${skill.agentsFile}: ${err.message}`);
+			}
+		}
+	}
+
+	console.log(
+		`\nGeneration complete: ${changed} regenerated, ${skipped} unchanged, ${synthesized} synthesized (skipped).`,
+	);
+	if (totalUsage.input || totalUsage.output) {
+		console.log(
+			`Model: ${generationModel()}  |  tokens in: ${totalUsage.input} ` +
+				`(cache read: ${totalUsage.cacheRead}), out: ${totalUsage.output}`,
+		);
+	}
+}
+
+main().catch((err) => {
+	console.error('generate-rules crashed:', err);
+	process.exit(2);
+});

--- a/scripts/generation/generate-rules.mjs
+++ b/scripts/generation/generate-rules.mjs
@@ -63,19 +63,17 @@ function resolveDocsSha(docsRepoPath) {
 	}
 }
 
-async function exists(p) {
-	try {
-		await fs.access(p);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-// Read the existing rule file's frontmatter metadata, if the file exists.
+// Read the existing rule file's frontmatter metadata, or null if the file
+// doesn't exist yet. Attempt the read and handle ENOENT rather than checking
+// for existence first — a separate check would race with the read.
 async function readExistingMeta(filePath) {
-	if (!(await exists(filePath))) return null;
-	const raw = await fs.readFile(filePath, 'utf-8');
+	let raw;
+	try {
+		raw = await fs.readFile(filePath, 'utf-8');
+	} catch (err) {
+		if (err.code === 'ENOENT') return null;
+		throw err;
+	}
 	return matter(raw).data?.metadata ?? null;
 }
 
@@ -83,15 +81,6 @@ async function main() {
 	const args = parseArgs(process.argv.slice(2));
 	const docsRepoPath = path.resolve(args.docsPath);
 	const docsBuildDir = path.join(docsRepoPath, 'build');
-
-	if (!(await exists(docsBuildDir))) {
-		console.error(
-			`Docs build directory not found: ${docsBuildDir}\n` +
-				`Check out HarperFast/documentation and run \`npm ci && npm run build\` there,\n` +
-				`then re-run with --docs-path <that-checkout> (or set DOCS_PATH).`,
-		);
-		process.exit(1);
-	}
 
 	const docsSha = resolveDocsSha(docsRepoPath);
 	console.log(`Docs build: ${docsBuildDir}`);
@@ -122,12 +111,19 @@ async function main() {
 				continue;
 			}
 
-			// Resolve + hash sources.
+			// Resolve + hash sources. A missing source surfaces here at the
+			// point of use (rather than via an upfront existence check).
 			let sourceContent;
 			try {
 				sourceContent = await resolveSources(docsBuildDir, entry.sources);
 			} catch (err) {
 				console.error(`✗ ${entry.rule}: failed to resolve sources — ${err.message}`);
+				if (err.code === 'ENOENT') {
+					console.error(
+						`  No flat-markdown found under ${docsBuildDir}. ` +
+							`Run \`npm ci && npm run build\` in the docs checkout (or fix --docs-path).`,
+					);
+				}
 				process.exit(1);
 			}
 			const inputHash = computeInputHash(sourceContent);

--- a/scripts/generation/generate-rules.mjs
+++ b/scripts/generation/generate-rules.mjs
@@ -195,9 +195,10 @@ async function main() {
 			await fs.writeFile(agentsPath, agentsMd, 'utf-8');
 			// Format AGENTS.md itself so the committed file equals
 			// oxfmt(assemble(formatted bodies)) — the exact value the validator
-			// recomputes for its round-trip equality check.
+			// recomputes for its round-trip equality check. execFileSync (no
+			// shell) avoids any quoting concern with the path argument.
 			try {
-				execSync(`npx oxfmt ${JSON.stringify(agentsPath)}`, { stdio: 'inherit' });
+				execFileSync('npx', ['oxfmt', agentsPath], { stdio: 'inherit' });
 			} catch (err) {
 				console.warn(`Could not format ${skill.agentsFile}: ${err.message}`);
 			}

--- a/scripts/generation/lib/llm.mjs
+++ b/scripts/generation/lib/llm.mjs
@@ -1,0 +1,116 @@
+// LLM-backed rule body generation (the `generate` mode body producer).
+// `direct` mode does not use this module — it imports the flat-markdown
+// verbatim. Uses the Anthropic SDK with a cached, stable system prompt.
+//
+// Model choice: defaults to claude-sonnet-4-6 with temperature 0. This is a
+// mechanical structured-rewrite task where deterministic, low-variance output
+// matters (reviewable diffs, the input-hash skip) and cost adds up across a
+// recurring multi-rule job — Sonnet 4.6 is the right fit and supports the
+// temperature knob. Override with GENERATE_MODEL if you want a different
+// model; note that claude-opus-4-7 removed `temperature` (it 400s), so if you
+// switch to it you must also drop the temperature field and use `effort`.
+
+import Anthropic from '@anthropic-ai/sdk';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+const MODEL = process.env.GENERATE_MODEL || 'claude-sonnet-4-6';
+const MAX_TOKENS = 8192;
+
+let _client;
+function client() {
+	if (!_client) {
+		// Reads ANTHROPIC_API_KEY from the environment.
+		_client = new Anthropic();
+	}
+	return _client;
+}
+
+let _systemPrompt;
+async function systemPrompt() {
+	if (_systemPrompt) return _systemPrompt;
+	const [sys, tmpl] = await Promise.all([
+		fs.readFile(path.join(TEMPLATES_DIR, 'system-prompt.md'), 'utf-8'),
+		fs.readFile(path.join(TEMPLATES_DIR, 'rule-template.md'), 'utf-8'),
+	]);
+	_systemPrompt = sys.replace('{{RULE_TEMPLATE}}', tmpl.trim());
+	return _systemPrompt;
+}
+
+export function generationModel() {
+	return MODEL;
+}
+
+// Generate a rule body from resolved source documentation.
+// Returns { body, usage }.
+export async function generateRuleBody({
+	rule,
+	description,
+	sourceContent,
+	mustCover,
+	crossLinks,
+}) {
+	const system = await systemPrompt();
+
+	const sections = [
+		`# Rule to generate: ${rule}`,
+		``,
+		`Agent-facing purpose of this rule: ${description}`,
+	];
+
+	if (mustCover?.length) {
+		sections.push(
+			``,
+			`## Must cover`,
+			`The rule body MUST include each of the following (verbatim for code/identifiers):`,
+			...mustCover.map((s) => `- ${s}`),
+		);
+	}
+
+	if (crossLinks?.length) {
+		sections.push(
+			``,
+			`## Related rules`,
+			`Where natural, link to these rules using the \`<slug>.md\` form:`,
+			...crossLinks.map((s) => `- ${s}.md`),
+		);
+	}
+
+	sections.push(
+		``,
+		`## Source documentation`,
+		`Rewrite the following into the rule body. Use only what is present here.`,
+		``,
+		`----`,
+		sourceContent,
+		`----`,
+	);
+
+	const response = await client().messages.create({
+		model: MODEL,
+		max_tokens: MAX_TOKENS,
+		temperature: 0,
+		// Stable across every rule in a run → cache it. Volatile per-rule
+		// content lives in the user message, after the cached prefix.
+		system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+		messages: [{ role: 'user', content: sections.join('\n') }],
+	});
+
+	const body = response.content
+		.filter((b) => b.type === 'text')
+		.map((b) => b.text)
+		.join('')
+		.trim();
+
+	if (!body) {
+		throw new Error(
+			`LLM returned empty body for rule "${rule}" (stop_reason: ${response.stop_reason})`,
+		);
+	}
+
+	return { body, usage: response.usage };
+}

--- a/scripts/generation/lib/llm.mjs
+++ b/scripts/generation/lib/llm.mjs
@@ -13,10 +13,8 @@
 import Anthropic from '@anthropic-ai/sdk';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+const TEMPLATES_DIR = path.join(import.meta.dirname, '..', 'templates');
 
 const MODEL = process.env.GENERATE_MODEL || 'claude-sonnet-4-6';
 const MAX_TOKENS = 8192;

--- a/scripts/generation/lib/manifest.mjs
+++ b/scripts/generation/lib/manifest.mjs
@@ -1,0 +1,57 @@
+// Shared manifest loading and skill metadata, used by both the generator
+// (generate-rules.mjs) and the validator (validate-generated.mjs).
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import yaml from 'js-yaml';
+
+// Each entry describes a skill directory. Add new skills here as they are
+// introduced (Story 5 in docs/plans/docs-driven-skills.md describes the
+// multi-skill case).
+export const SKILLS = [
+	{
+		dir: 'harper-best-practices',
+		manifestFile: 'rules.manifest.yaml',
+		rulesDir: 'rules',
+		skillFile: 'SKILL.md',
+		agentsFile: 'AGENTS.md',
+	},
+];
+
+// Display labels for categories, used when assembling AGENTS.md. The manifest
+// stores the short enum (schema/api/logic/ops); these are the human headings.
+export const CATEGORY_LABELS = {
+	schema: 'Schema & Data Design',
+	api: 'API & Communication',
+	logic: 'Logic & Extension',
+	ops: 'Infrastructure & Ops',
+};
+
+export const VALID_MODES = new Set(['generate', 'direct', 'synthesized']);
+export const VALID_CATEGORIES = new Set(Object.keys(CATEGORY_LABELS));
+export const VALID_SOURCE_ROLES = new Set(['primary', 'supplemental']);
+
+// Load and parse a skill's manifest YAML. Throws on read/parse failure.
+export async function loadManifest(skill) {
+	const manifestPath = path.join(process.cwd(), skill.dir, skill.manifestFile);
+	const raw = await fs.readFile(manifestPath, 'utf-8');
+	return yaml.load(raw);
+}
+
+// Manifest rules in display order: by category priority, then order within
+// the category. Returns a new array; does not mutate the manifest.
+export function sortedRules(manifest) {
+	return [...manifest.rules].sort((a, b) => {
+		if (a.priority !== b.priority) return a.priority - b.priority;
+		return a.order - b.order;
+	});
+}
+
+// Normalize a manifest source entry to a `path[#section]` string. Used both
+// for writing frontmatter metadata.sources and for reconciling it.
+export function normalizeSource(source) {
+	if (typeof source === 'string') return source;
+	if (!source || typeof source.path !== 'string') return null;
+	return source.section ? `${source.path}#${source.section}` : source.path;
+}

--- a/scripts/generation/lib/render.mjs
+++ b/scripts/generation/lib/render.mjs
@@ -1,0 +1,94 @@
+// Rendering helpers: compose individual rule files (frontmatter + body) and
+// assemble the flat AGENTS.md from all rule bodies. Both the generator and the
+// validator use assembleAgentsMd (the validator for the round-trip equality
+// check). Keeping assembly here means there is exactly one definition of "what
+// AGENTS.md should look like".
+
+import matter from 'gray-matter';
+import { CATEGORY_LABELS, normalizeSource, sortedRules } from './manifest.mjs';
+
+// Build the frontmatter object for a rule file from its manifest entry plus
+// generator-written provenance. synthesized rules carry only mode.
+export function buildFrontmatter(entry, { sourceCommit, inputHash } = {}) {
+	const metadata = { mode: entry.mode };
+	if (entry.mode === 'generate' || entry.mode === 'direct') {
+		metadata.sources = entry.sources.map(normalizeSource);
+		metadata.sourceCommit = sourceCommit;
+		metadata.inputHash = inputHash;
+	}
+	return { name: entry.rule, description: entry.description, metadata };
+}
+
+// Compose a complete rule file (frontmatter + body). The body is expected to
+// start with its H1. Output is later run through oxfmt by the generator.
+export function composeRuleFile(frontmatter, body) {
+	return matter.stringify(`\n${body.trim()}\n`, frontmatter);
+}
+
+// Shift every Markdown ATX heading in `body` down by `delta` levels, capping at
+// h6. Used to nest rule bodies under category/rule headings in AGENTS.md.
+function shiftHeadings(body, delta) {
+	return body
+		.split('\n')
+		.map((line) => {
+			const m = line.match(/^(#{1,6})(\s+.*)$/);
+			if (!m) return line;
+			const level = Math.min(6, m[1].length + delta);
+			return '#'.repeat(level) + m[2];
+		})
+		.join('\n');
+}
+
+// Strip the leading H1 line from a rule body, returning { title, rest }.
+function splitTitle(body) {
+	const lines = body.trim().split('\n');
+	const m = lines[0].match(/^#\s+(.*)$/);
+	if (!m) return { title: null, rest: body.trim() };
+	return { title: m[1].trim(), rest: lines.slice(1).join('\n').trim() };
+}
+
+// Assemble the flat AGENTS.md document from all rule bodies, grouped by
+// category in manifest order. Deterministic: same manifest + same rule bodies
+// always produce byte-identical output. `readBody(slug)` returns the rule's
+// body (frontmatter already stripped).
+export function assembleAgentsMd(manifest, readBody, { lead } = {}) {
+	const rules = sortedRules(manifest);
+
+	const out = ['# Harper Best Practices', ''];
+	if (lead) out.push(lead.trim(), '');
+
+	// Group rules by category, preserving first-seen category order.
+	const categories = [];
+	const byCategory = new Map();
+	for (const rule of rules) {
+		if (!byCategory.has(rule.category)) {
+			byCategory.set(rule.category, []);
+			categories.push(rule.category);
+		}
+		byCategory.get(rule.category).push(rule);
+	}
+
+	categories.forEach((category, ci) => {
+		const categoryNum = ci + 1;
+		out.push(`## ${categoryNum}. ${CATEGORY_LABELS[category] || category}`, '');
+		byCategory.get(category).forEach((rule, ri) => {
+			const { title, rest } = splitTitle(readBody(rule.rule));
+			const heading = `### ${categoryNum}.${ri + 1} ${title || rule.rule}`;
+			// The rule's H1 title becomes this H3; body sub-headings shift down by
+			// 2 so the top-level ones (## When to Use) land at H4, nested under it.
+			out.push(heading, '', shiftHeadings(rest, 2), '');
+		});
+	});
+
+	return (
+		out
+			.join('\n')
+			.replace(/\n{3,}/g, '\n\n')
+			.trim() + '\n'
+	);
+}
+
+// Read a rule body (strip frontmatter) from raw file content.
+export function bodyOf(rawRuleFile) {
+	return matter(rawRuleFile).content.trim();
+}

--- a/scripts/generation/lib/render.mjs
+++ b/scripts/generation/lib/render.mjs
@@ -27,10 +27,18 @@ export function composeRuleFile(frontmatter, body) {
 
 // Shift every Markdown ATX heading in `body` down by `delta` levels, capping at
 // h6. Used to nest rule bodies under category/rule headings in AGENTS.md.
+// Skips lines inside fenced code blocks so that `#`-leading code (YAML/bash/
+// GraphQL comments) is never mistaken for a heading.
 function shiftHeadings(body, delta) {
+	let inFence = false;
 	return body
 		.split('\n')
 		.map((line) => {
+			if (/^\s*(`{3,}|~{3,})/.test(line)) {
+				inFence = !inFence;
+				return line;
+			}
+			if (inFence) return line;
 			const m = line.match(/^(#{1,6})(\s+.*)$/);
 			if (!m) return line;
 			const level = Math.min(6, m[1].length + delta);

--- a/scripts/generation/lib/sources.mjs
+++ b/scripts/generation/lib/sources.mjs
@@ -35,15 +35,24 @@ export async function resolveSources(docsBuildDir, sources) {
 
 // Extract the Markdown subtree under the heading whose text matches `section`.
 // The slice runs from the matching heading up to (but not including) the next
-// heading at the same or shallower level. Throws if the heading isn't found.
+// heading at the same or shallower level. Lines inside fenced code blocks are
+// not considered headings (a `## foo` inside a ``` block is code, not a
+// boundary). Throws if the heading isn't found.
 export function sliceSection(markdown, section, sourcePathForError = '') {
 	const lines = markdown.split('\n');
 	const headingRe = /^(#{1,6})\s+(.*?)\s*$/;
+	const fenceRe = /^\s*(`{3,}|~{3,})/;
 	const target = normalizeHeading(section);
 
+	let inFence = false;
 	let start = -1;
 	let startLevel = 0;
 	for (let i = 0; i < lines.length; i++) {
+		if (fenceRe.test(lines[i])) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
 		const m = lines[i].match(headingRe);
 		if (m && normalizeHeading(m[2]) === target) {
 			start = i;
@@ -56,8 +65,16 @@ export function sliceSection(markdown, section, sourcePathForError = '') {
 		throw new Error(`Section heading "${section}" not found${where}`);
 	}
 
+	// The start line is a heading (never inside a fence), so fence state at
+	// start+1 is closed.
+	inFence = false;
 	let end = lines.length;
 	for (let i = start + 1; i < lines.length; i++) {
+		if (fenceRe.test(lines[i])) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
 		const m = lines[i].match(headingRe);
 		if (m && m[1].length <= startLevel) {
 			end = i;

--- a/scripts/generation/lib/sources.mjs
+++ b/scripts/generation/lib/sources.mjs
@@ -1,0 +1,80 @@
+// Source resolution against the docs build output. Shared by the generator
+// (to feed the LLM / produce direct bodies) and the validator (source-exists
+// and byte-identical checks). The docs build dir is the `build/` tree produced
+// by @signalwire/docusaurus-plugin-llms-txt — see Phase 1 in
+// docs/plans/docs-driven-skills.md. No network access: everything reads from
+// the local checked-out-and-built docs tree.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+// Resolve the absolute path of a manifest source within the docs build dir.
+export function sourceFilePath(docsBuildDir, source) {
+	return path.join(docsBuildDir, source.path);
+}
+
+// Read one manifest source, slicing to a section if `source.section` is set.
+export async function readSource(docsBuildDir, source) {
+	const filePath = sourceFilePath(docsBuildDir, source);
+	const content = await fs.readFile(filePath, 'utf-8');
+	if (source.section) {
+		return sliceSection(content, source.section, source.path);
+	}
+	return content.trim();
+}
+
+// Resolve and concatenate all sources for a rule, in manifest order.
+export async function resolveSources(docsBuildDir, sources) {
+	const parts = [];
+	for (const source of sources) {
+		parts.push(await readSource(docsBuildDir, source));
+	}
+	return parts.join('\n\n');
+}
+
+// Extract the Markdown subtree under the heading whose text matches `section`.
+// The slice runs from the matching heading up to (but not including) the next
+// heading at the same or shallower level. Throws if the heading isn't found.
+export function sliceSection(markdown, section, sourcePathForError = '') {
+	const lines = markdown.split('\n');
+	const headingRe = /^(#{1,6})\s+(.*?)\s*$/;
+	const target = normalizeHeading(section);
+
+	let start = -1;
+	let startLevel = 0;
+	for (let i = 0; i < lines.length; i++) {
+		const m = lines[i].match(headingRe);
+		if (m && normalizeHeading(m[2]) === target) {
+			start = i;
+			startLevel = m[1].length;
+			break;
+		}
+	}
+	if (start === -1) {
+		const where = sourcePathForError ? ` in ${sourcePathForError}` : '';
+		throw new Error(`Section heading "${section}" not found${where}`);
+	}
+
+	let end = lines.length;
+	for (let i = start + 1; i < lines.length; i++) {
+		const m = lines[i].match(headingRe);
+		if (m && m[1].length <= startLevel) {
+			end = i;
+			break;
+		}
+	}
+	return lines.slice(start, end).join('\n').trim();
+}
+
+function normalizeHeading(s) {
+	return s.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+// Deterministic short hash of resolved source content. Drives the no-op skip:
+// if a rule's stored metadata.inputHash matches, the source is unchanged and
+// the body does not need regenerating. Mode-independent — both generate and
+// direct hash the same resolved input.
+export function computeInputHash(content) {
+	return crypto.createHash('sha256').update(content, 'utf-8').digest('hex').slice(0, 16);
+}

--- a/scripts/generation/templates/rule-template.md
+++ b/scripts/generation/templates/rule-template.md
@@ -1,0 +1,21 @@
+# <Rule Title>
+
+<One sentence stating what this rule instructs the agent to do, e.g. "Instructions for the agent to follow when implementing vector search in Harper.">
+
+## When to Use
+
+<1–3 sentences describing the concrete scenarios where an agent should apply this rule. Be specific about the triggering situation.>
+
+## How It Works
+
+<A numbered list of the steps an agent takes to accomplish the task. Each step is bold-led with a short imperative label, followed by explanation and code where relevant. Include the real directives, methods, and parameters from the source. Example shape:>
+
+1. **<Imperative label>**: <what to do>.
+   ```graphql
+   <code from source>
+   ```
+2. **<Imperative label>**: <what to do>.
+
+## Examples
+
+<One or more concrete, copy-pasteable examples drawn from the source — a schema snippet, a query, a request. If the source has no example beyond what's already shown above, include the most representative end-to-end snippet.>

--- a/scripts/generation/templates/system-prompt.md
+++ b/scripts/generation/templates/system-prompt.md
@@ -1,0 +1,26 @@
+You are a technical writer producing a single "rule" file for the Harper Best Practices agent skill. A rule is a focused, action-oriented instruction document that an AI coding agent reads on demand when working on a specific Harper task. Your job is to rewrite the provided Harper documentation into a rule body that follows the exact structure below.
+
+## Audience and voice
+
+The reader is an AI agent writing Harper application code, not a human browsing docs. Write imperatively and concretely. Lead with what to do, then how. Prefer short, scannable steps and real code over prose. Assume the agent will act on every sentence.
+
+## Hard rules
+
+1. **Do not invent.** Use only facts, APIs, directives, parameters, and code present in the provided source documentation. If the source doesn't state something, do not include it. Never guess at API names, parameter defaults, or behavior.
+2. **Preserve identifiers verbatim.** Type names, directives (`@table`, `@indexed`), method names, config keys, parameter names, and code must match the source exactly.
+3. **Output only the rule body in Markdown.** No frontmatter, no preamble, no closing commentary, no code fence around the whole thing. Start directly with the H1 title.
+4. **Cover every "must cover" item** if a "Must cover" list is provided. Each listed string must appear in your output (verbatim for code/identifiers).
+5. **Keep it tight.** This is a rule, not a doc page. Omit marketing language, version-history asides, and tangential detail. Aim for the essential, actionable core.
+
+## Required structure
+
+Produce exactly this structure:
+
+{{RULE_TEMPLATE}}
+
+## Notes
+
+- Use fenced code blocks with a language tag where the source does (`graphql, `javascript, `typescript, `bash, `json, `yaml).
+- If the source includes a parameter/option table that is essential to using the feature, you may include a compact Markdown table under "How It Works".
+- If "Related rules" are provided, weave in Markdown links to them where natural (e.g. `See [caching](caching.md)`), using the `<slug>.md` form. Do not fabricate links to rules not listed.
+- Do not include "Added in vX" version badges or changelog notes — they are noise for an agent.

--- a/scripts/generation/validate-generated.mjs
+++ b/scripts/generation/validate-generated.mjs
@@ -1,394 +1,337 @@
 // Validator for the docs-driven skill generation system.
 //
-// Implements Layers 2 and 3 of the validation taxonomy defined in
+// Implements Layers 2–4 of the validation taxonomy in
 // docs/plans/docs-driven-skills.md:
 //
-//   - Layer 2 (manifest lint): the manifest itself conforms to the schema.
+//   - Layer 2 (manifest lint): the manifest conforms to the schema.
 //   - Layer 3 (manifest ↔ frontmatter reconciliation): each rule file's
-//     frontmatter matches what the manifest declares for that rule. This is
-//     the gate that makes the manifest causally authoritative — any
-//     divergence here means either the rule needs regenerating or the
-//     manifest needs fixing.
+//     frontmatter matches the manifest. This is the gate that makes the
+//     manifest causally authoritative.
+//   - Layer 4 (per-mode body checks): generated/imported rule bodies satisfy
+//     the per-mode invariants (must-cover, byte-identical, min length, no
+//     leaked MDX, source-exists), plus AGENTS.md round-trip equality.
 //
-// Layer 4 (per-mode body checks) is added in Phase 2 when generation lands.
+// Layer 1 (basic skill schema) is handled separately by validate-skills.mjs.
 //
-// This script is run via `npm run validate` after the existing
-// validate-skills.mjs. It exits non-zero on any failure with a precise error
-// pointing at the offending field or file.
+// Some Layer 4 checks need the docs build output (source-exists,
+// byte-identical). Pass --docs-path <docs-checkout> to enable them; without
+// it they are skipped with a note. CI runs with --docs-path; a bare local
+// `npm run validate` runs everything that doesn't require docs.
 
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import yaml from 'js-yaml';
+import { execFileSync } from 'node:child_process';
 import matter from 'gray-matter';
 
-// Each entry describes a skill directory containing SKILL.md, rules/, and
-// rules.manifest.yaml. Add new skills here as they are introduced (Story 5
-// in the plan describes the multi-skill case).
-const SKILLS = [
-	{
-		dir: 'harper-best-practices',
-		manifestFile: 'rules.manifest.yaml',
-		rulesDir: 'rules',
-	},
-];
+import {
+	loadManifest,
+	normalizeSource,
+	SKILLS,
+	VALID_CATEGORIES,
+	VALID_MODES,
+	VALID_SOURCE_ROLES,
+} from './lib/manifest.mjs';
+import { computeInputHash, resolveSources, sourceFilePath } from './lib/sources.mjs';
+import { assembleAgentsMd, bodyOf } from './lib/render.mjs';
 
-const VALID_MODES = new Set(['generate', 'direct', 'synthesized']);
-const VALID_CATEGORIES = new Set(['schema', 'api', 'logic', 'ops']);
-const VALID_SOURCE_ROLES = new Set(['primary', 'supplemental']);
+const AGENTS_LEAD =
+	'Guidelines for building scalable, secure, and performant applications on Harper. These practices cover everything from initial schema design to advanced deployment strategies.';
 
-class ValidationError extends Error {
-	constructor(scope, message) {
-		super(`[${scope}] ${message}`);
-		this.scope = scope;
+const MIN_GENERATED_BODY_CHARS = 200;
+
+function parseArgs(argv) {
+	const args = { docsPath: process.env.DOCS_PATH || null };
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === '--docs-path') args.docsPath = argv[++i];
 	}
+	return args;
 }
 
-function isPlainObject(value) {
-	return value !== null && typeof value === 'object' && !Array.isArray(value);
+function isPlainObject(v) {
+	return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+function isPositiveInteger(v) {
+	return Number.isInteger(v) && v > 0;
+}
+function isNonEmptyString(v) {
+	return typeof v === 'string' && v.length > 0;
 }
 
-function isPositiveInteger(value) {
-	return Number.isInteger(value) && value > 0;
-}
-
-function isNonEmptyString(value) {
-	return typeof value === 'string' && value.length > 0;
-}
-
-// Normalize a manifest source entry to a `path[#section]` string for
-// comparison against frontmatter metadata.sources entries.
-function normalizeManifestSource(source) {
-	if (typeof source === 'string') return source;
-	if (!isPlainObject(source) || !isNonEmptyString(source.path)) return null;
-	return source.section ? `${source.path}#${source.section}` : source.path;
+// Remove fenced and inline code so leaked-MDX heuristics don't false-positive
+// on legitimate `import`/JSX-like syntax inside code examples.
+function stripCode(md) {
+	return md.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
 }
 
 // ===========================================================================
 // Layer 2 — Manifest lint
 // ===========================================================================
 
-function lintManifest(manifest, scope) {
-	const errors = [];
-
-	if (!isPlainObject(manifest)) {
-		errors.push('Manifest root must be an object');
-		return errors;
+function lintManifest(manifest, scope, errors) {
+	if (!isPlainObject(manifest) || !Array.isArray(manifest.rules)) {
+		errors.push(`[${scope}] Manifest must be an object with a \`rules\` array`);
+		return false;
 	}
 
-	if (!Array.isArray(manifest.rules)) {
-		errors.push('Manifest must have a `rules` array at the root');
-		return errors;
-	}
-
-	const seenSlugs = new Set();
+	const seen = new Set();
 	const allSlugs = new Set(manifest.rules.map((r) => r?.rule).filter(isNonEmptyString));
 
-	manifest.rules.forEach((entry, index) => {
-		const where = `rules[${index}]${entry?.rule ? ` (${entry.rule})` : ''}`;
-
-		if (!isPlainObject(entry)) {
+	for (let i = 0; i < manifest.rules.length; i++) {
+		const e = manifest.rules[i];
+		const where = `[${scope}] rules[${i}]${e?.rule ? ` (${e.rule})` : ''}`;
+		if (!isPlainObject(e)) {
 			errors.push(`${where}: must be an object`);
-			return;
+			continue;
+		}
+		for (const f of ['rule', 'description']) {
+			if (!isNonEmptyString(e[f])) errors.push(`${where}: missing or non-string "${f}"`);
+		}
+		if (isNonEmptyString(e.rule)) {
+			if (!/^[a-z0-9-]+$/.test(e.rule))
+				errors.push(`${where}: "rule" must be lowercase/digits/hyphens`);
+			if (seen.has(e.rule)) errors.push(`${where}: duplicate slug`);
+			seen.add(e.rule);
+		}
+		if (!VALID_CATEGORIES.has(e.category)) {
+			errors.push(`${where}: "category" must be one of ${[...VALID_CATEGORIES].join(' / ')}`);
+		}
+		for (const f of ['priority', 'order']) {
+			if (!isPositiveInteger(e[f])) errors.push(`${where}: "${f}" must be a positive integer`);
+		}
+		if (!VALID_MODES.has(e.mode)) {
+			errors.push(`${where}: "mode" must be one of ${[...VALID_MODES].join(' / ')}`);
 		}
 
-		// Required string fields.
-		for (const field of ['rule', 'description']) {
-			if (!isNonEmptyString(entry[field])) {
-				errors.push(`${where}: missing or non-string field "${field}"`);
-			}
-		}
-
-		// Rule slug shape.
-		if (isNonEmptyString(entry.rule)) {
-			if (!/^[a-z0-9-]+$/.test(entry.rule)) {
-				errors.push(`${where}: "rule" must be lowercase letters, digits, and hyphens only`);
-			}
-			if (seenSlugs.has(entry.rule)) {
-				errors.push(`${where}: duplicate "rule" slug`);
-			} else {
-				seenSlugs.add(entry.rule);
-			}
-		}
-
-		// Category enum.
-		if (!VALID_CATEGORIES.has(entry.category)) {
-			errors.push(
-				`${where}: "category" must be one of ${[...VALID_CATEGORIES].join(' / ')} (got ${JSON.stringify(entry.category)})`,
-			);
-		}
-
-		// Positive integer ordering fields.
-		for (const field of ['priority', 'order']) {
-			if (!isPositiveInteger(entry[field])) {
-				errors.push(`${where}: "${field}" must be a positive integer`);
-			}
-		}
-
-		// Mode enum.
-		if (!VALID_MODES.has(entry.mode)) {
-			errors.push(
-				`${where}: "mode" must be one of ${[...VALID_MODES].join(' / ')} (got ${JSON.stringify(entry.mode)})`,
-			);
-		}
-
-		// Sources rules: required for generate/direct, must be a non-empty
-		// array of well-formed entries.
-		const needsSources = entry.mode === 'generate' || entry.mode === 'direct';
+		const needsSources = e.mode === 'generate' || e.mode === 'direct';
 		if (needsSources) {
-			if (!Array.isArray(entry.sources) || entry.sources.length === 0) {
-				errors.push(
-					`${where}: "sources" is required and must be non-empty for mode "${entry.mode}"`,
-				);
+			if (!Array.isArray(e.sources) || e.sources.length === 0) {
+				errors.push(`${where}: "sources" required and non-empty for mode "${e.mode}"`);
 			} else {
-				entry.sources.forEach((src, srcIndex) => {
-					const srcWhere = `${where}.sources[${srcIndex}]`;
-					if (!isPlainObject(src)) {
-						errors.push(`${srcWhere}: must be an object`);
-						return;
+				e.sources.forEach((s, si) => {
+					const sw = `${where}.sources[${si}]`;
+					if (!isPlainObject(s)) return errors.push(`${sw}: must be an object`);
+					if (!isNonEmptyString(s.path)) errors.push(`${sw}: missing "path"`);
+					else if (s.path.startsWith('/') || s.path.includes('..')) {
+						errors.push(`${sw}: "path" must be relative without "..": ${JSON.stringify(s.path)}`);
 					}
-					if (!isNonEmptyString(src.path)) {
-						errors.push(`${srcWhere}: missing or non-string "path"`);
-					} else if (src.path.startsWith('/') || src.path.includes('..')) {
-						errors.push(
-							`${srcWhere}: "path" must be relative and not contain "..": got ${JSON.stringify(src.path)}`,
-						);
+					if (s.section !== undefined && !isNonEmptyString(s.section)) {
+						errors.push(`${sw}: "section" must be a non-empty string`);
 					}
-					if (src.section !== undefined && !isNonEmptyString(src.section)) {
-						errors.push(`${srcWhere}: "section" must be a non-empty string when present`);
-					}
-					if (src.role !== undefined && !VALID_SOURCE_ROLES.has(src.role)) {
-						errors.push(
-							`${srcWhere}: "role" must be one of ${[...VALID_SOURCE_ROLES].join(' / ')} (got ${JSON.stringify(src.role)})`,
-						);
+					if (s.role !== undefined && !VALID_SOURCE_ROLES.has(s.role)) {
+						errors.push(`${sw}: "role" must be one of ${[...VALID_SOURCE_ROLES].join(' / ')}`);
 					}
 				});
 			}
-		} else if (entry.sources !== undefined) {
-			errors.push(`${where}: "sources" must be omitted for mode "${entry.mode}"`);
+		} else if (e.sources !== undefined) {
+			errors.push(`${where}: "sources" must be omitted for mode "${e.mode}"`);
 		}
 
-		// must_cover: required non-empty array for generate mode.
-		if (entry.mode === 'generate') {
-			if (entry.must_cover !== undefined) {
-				if (!Array.isArray(entry.must_cover)) {
-					errors.push(`${where}: "must_cover" must be an array`);
-				} else {
-					entry.must_cover.forEach((item, i) => {
-						if (!isNonEmptyString(item)) {
-							errors.push(`${where}.must_cover[${i}]: must be a non-empty string`);
-						}
+		if (e.mode === 'generate') {
+			if (e.must_cover !== undefined) {
+				if (!Array.isArray(e.must_cover)) errors.push(`${where}: "must_cover" must be an array`);
+				else {
+					e.must_cover.forEach((m, mi) => {
+						if (!isNonEmptyString(m))
+							errors.push(`${where}.must_cover[${mi}]: must be a non-empty string`);
 					});
 				}
 			}
-		} else if (entry.must_cover !== undefined) {
+		} else if (e.must_cover !== undefined) {
 			errors.push(`${where}: "must_cover" only applies to mode "generate"`);
 		}
 
-		// cross_links: optional array of slugs that must reference real rules.
-		if (entry.cross_links !== undefined) {
-			if (!Array.isArray(entry.cross_links)) {
-				errors.push(`${where}: "cross_links" must be an array of slugs`);
-			} else {
-				entry.cross_links.forEach((slug, i) => {
-					if (!isNonEmptyString(slug)) {
-						errors.push(`${where}.cross_links[${i}]: must be a non-empty string`);
-					} else if (!allSlugs.has(slug)) {
-						errors.push(`${where}.cross_links[${i}]: references unknown rule "${slug}"`);
-					}
+		if (e.cross_links !== undefined) {
+			if (!Array.isArray(e.cross_links)) errors.push(`${where}: "cross_links" must be an array`);
+			else {
+				e.cross_links.forEach((c, ci) => {
+					if (!isNonEmptyString(c))
+						errors.push(`${where}.cross_links[${ci}]: must be a non-empty string`);
+					else if (!allSlugs.has(c))
+						errors.push(`${where}.cross_links[${ci}]: unknown rule "${c}"`);
 				});
 			}
 		}
-	});
-
-	return errors.map((msg) => new ValidationError(scope, msg));
+	}
+	return errors.length === 0;
 }
 
 // ===========================================================================
-// Layer 3 — Manifest ↔ frontmatter reconciliation
+// Layer 3 — Manifest ↔ frontmatter reconciliation, and Layer 4 body checks
 // ===========================================================================
 
-async function reconcileManifestAndFrontmatter(manifest, skill, scope) {
-	const errors = [];
+async function checkRules(manifest, skill, scope, docsBuildDir, errors) {
 	const rulesDir = path.join(process.cwd(), skill.dir, skill.rulesDir);
+	const manifestSlugs = new Set(manifest.rules.map((r) => r.rule));
 
-	// Build the set of manifest slugs for quick lookup.
-	const manifestSlugs = new Set();
-	for (const entry of manifest.rules) {
-		if (isNonEmptyString(entry?.rule)) manifestSlugs.add(entry.rule);
-	}
-
-	// Check that every rule file on disk has a manifest entry.
-	let onDiskFiles;
-	try {
-		onDiskFiles = await fs.readdir(rulesDir);
-	} catch (err) {
-		errors.push(
-			new ValidationError(scope, `Cannot read rules directory ${rulesDir}: ${err.message}`),
-		);
-		return errors;
-	}
-	const onDiskSlugs = new Set();
-	for (const file of onDiskFiles) {
-		if (file.endsWith('.md')) {
-			onDiskSlugs.add(path.basename(file, '.md'));
-		}
-	}
-	for (const slug of onDiskSlugs) {
+	// Orphan rule files (on disk but not in manifest).
+	const onDisk = (await fs.readdir(rulesDir)).filter((f) => f.endsWith('.md'));
+	for (const f of onDisk) {
+		const slug = path.basename(f, '.md');
 		if (!manifestSlugs.has(slug)) {
-			errors.push(
-				new ValidationError(
-					scope,
-					`Rule file "${slug}.md" exists on disk but has no manifest entry`,
-				),
-			);
+			errors.push(`[${scope}] rules[${slug}]: file exists on disk but has no manifest entry`);
 		}
 	}
 
-	// For each manifest entry, validate its rule file.
-	for (let i = 0; i < manifest.rules.length; i++) {
-		const entry = manifest.rules[i];
-		if (!isPlainObject(entry) || !isNonEmptyString(entry.rule)) continue;
-
+	for (const entry of manifest.rules) {
 		const slug = entry.rule;
+		const where = `[${scope}] rules[${slug}]`;
 		const filePath = path.join(rulesDir, `${slug}.md`);
-		const where = `rules[${slug}]`;
 
 		let raw;
 		try {
 			raw = await fs.readFile(filePath, 'utf-8');
-		} catch (err) {
-			errors.push(
-				new ValidationError(
-					scope,
-					`${where}: manifest declares rule but file "${path.relative(process.cwd(), filePath)}" is missing (${err.code || err.message})`,
-				),
-			);
+		} catch {
+			errors.push(`${where}: manifest declares rule but ${slug}.md is missing`);
 			continue;
 		}
 
-		let parsed;
-		try {
-			parsed = matter(raw);
-		} catch (err) {
-			errors.push(
-				new ValidationError(scope, `${where}: failed to parse frontmatter: ${err.message}`),
-			);
-			continue;
-		}
+		const parsed = matter(raw);
 		const fm = parsed.data;
+		const body = parsed.content.trim();
 
-		// name must match the slug.
-		if (fm.name !== slug) {
-			errors.push(
-				new ValidationError(
-					scope,
-					`${where}: frontmatter "name" (${JSON.stringify(fm.name)}) must match slug "${slug}"`,
-				),
-			);
-		}
-
-		// description must match the manifest declaration.
+		// --- Layer 3: reconciliation ---
+		if (fm.name !== slug) errors.push(`${where}: frontmatter "name" must equal "${slug}"`);
 		if (fm.description !== entry.description) {
-			errors.push(
-				new ValidationError(
-					scope,
-					`${where}: frontmatter "description" diverges from manifest (regenerate or sync the manifest)`,
-				),
-			);
+			errors.push(`${where}: frontmatter "description" diverges from manifest`);
 		}
-
-		// metadata block presence + mode reconciliation.
 		const meta = fm.metadata;
 		if (!isPlainObject(meta)) {
-			errors.push(
-				new ValidationError(scope, `${where}: frontmatter must have a "metadata" object`),
-			);
+			errors.push(`${where}: frontmatter must have a "metadata" object`);
 			continue;
 		}
 		if (meta.mode !== entry.mode) {
 			errors.push(
-				new ValidationError(
-					scope,
-					`${where}: frontmatter metadata.mode (${JSON.stringify(meta.mode)}) does not match manifest mode (${JSON.stringify(entry.mode)})`,
-				),
+				`${where}: metadata.mode (${JSON.stringify(meta.mode)}) != manifest mode (${JSON.stringify(entry.mode)})`,
 			);
 		}
 
-		// For generate/direct: sources, sourceCommit, inputHash must be present
-		// and metadata.sources must match the manifest sources (normalized).
 		if (entry.mode === 'generate' || entry.mode === 'direct') {
-			if (!isNonEmptyString(meta.sourceCommit)) {
-				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.sourceCommit is required for mode "${entry.mode}"`,
-					),
-				);
-			}
-			if (!isNonEmptyString(meta.inputHash)) {
-				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.inputHash is required for mode "${entry.mode}"`,
-					),
-				);
-			}
-
-			if (!Array.isArray(meta.sources)) {
-				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.sources must be an array for mode "${entry.mode}"`,
-					),
-				);
-			} else {
-				const manifestNormalized = entry.sources
-					.map(normalizeManifestSource)
-					.filter((s) => s !== null);
-				const frontmatterNormalized = meta.sources.filter(isNonEmptyString);
-				const same =
-					manifestNormalized.length === frontmatterNormalized.length &&
-					manifestNormalized.every((s, idx) => s === frontmatterNormalized[idx]);
-				if (!same) {
-					errors.push(
-						new ValidationError(
-							scope,
-							`${where}: frontmatter metadata.sources does not match manifest sources (regenerate this rule)`,
-						),
-					);
-				}
+			if (!isNonEmptyString(meta.sourceCommit))
+				errors.push(`${where}: metadata.sourceCommit required`);
+			if (!isNonEmptyString(meta.inputHash)) errors.push(`${where}: metadata.inputHash required`);
+			const manifestNorm = entry.sources.map(normalizeSource);
+			const fmNorm = Array.isArray(meta.sources) ? meta.sources : [];
+			if (manifestNorm.length !== fmNorm.length || !manifestNorm.every((s, i) => s === fmNorm[i])) {
+				errors.push(`${where}: metadata.sources does not match manifest sources (regenerate)`);
 			}
 		} else {
-			// synthesized: no source-related metadata expected.
-			if (meta.sources !== undefined) {
-				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.sources must be omitted for mode "synthesized"`,
-					),
-				);
+			for (const f of ['sources', 'sourceCommit', 'inputHash']) {
+				if (meta[f] !== undefined)
+					errors.push(`${where}: metadata.${f} must be omitted for synthesized`);
 			}
-			if (meta.sourceCommit !== undefined) {
+		}
+
+		// --- Layer 4: per-mode body checks ---
+		if (entry.mode === 'generate' || entry.mode === 'direct') {
+			// No leaked MDX: JSX components or MDX `import` statements that appear
+			// outside fenced/inline code. Code examples legitimately contain
+			// `import ... from` and `<Generic>` type params, so strip code first.
+			const prose = stripCode(body);
+			if (/^import\s.+\sfrom\s/m.test(prose) || /<[A-Z][A-Za-z0-9]*[\s/>]/.test(prose)) {
 				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.sourceCommit must be omitted for mode "synthesized"`,
-					),
-				);
-			}
-			if (meta.inputHash !== undefined) {
-				errors.push(
-					new ValidationError(
-						scope,
-						`${where}: frontmatter metadata.inputHash must be omitted for mode "synthesized"`,
-					),
+					`${where}: body contains leaked MDX (JSX component or import outside a code block)`,
 				);
 			}
 		}
+		if (entry.mode === 'generate') {
+			if (body.length < MIN_GENERATED_BODY_CHARS) {
+				errors.push(
+					`${where}: generated body suspiciously short (${body.length} < ${MIN_GENERATED_BODY_CHARS} chars)`,
+				);
+			}
+			for (const must of entry.must_cover ?? []) {
+				if (!body.includes(must)) {
+					errors.push(`${where}: must_cover string not found in body: ${JSON.stringify(must)}`);
+				}
+			}
+		}
+
+		// Docs-dependent Layer 4 checks (CI only).
+		if (docsBuildDir && (entry.mode === 'generate' || entry.mode === 'direct')) {
+			for (const source of entry.sources) {
+				if (!fsSync.existsSync(sourceFilePath(docsBuildDir, source))) {
+					errors.push(`${where}: source not found in docs build: ${source.path}`);
+				}
+			}
+			if (entry.mode === 'direct') {
+				try {
+					const resolved = await resolveSources(docsBuildDir, entry.sources);
+					if (resolved.trim() !== body) {
+						errors.push(
+							`${where}: direct body is not byte-identical to its flat-markdown source (regenerate)`,
+						);
+					}
+					if (meta.inputHash && computeInputHash(resolved) !== meta.inputHash) {
+						errors.push(`${where}: metadata.inputHash is stale vs current source (regenerate)`);
+					}
+				} catch (err) {
+					errors.push(`${where}: cannot resolve sources for byte-identical check — ${err.message}`);
+				}
+			}
+		}
+	}
+}
+
+// ===========================================================================
+// AGENTS.md round-trip equality
+// ===========================================================================
+
+function oxfmtString(content) {
+	const tmp = path.join(os.tmpdir(), `validate-roundtrip-${process.pid}-${Date.now()}.md`);
+	fsSync.writeFileSync(tmp, content);
+	try {
+		execFileSync('npx', ['oxfmt', '--config', path.join(process.cwd(), '.oxfmtrc.json'), tmp], {
+			stdio: 'ignore',
+		});
+		return fsSync.readFileSync(tmp, 'utf-8');
+	} finally {
+		try {
+			fsSync.unlinkSync(tmp);
+		} catch {
+			/* ignore */
+		}
+	}
+}
+
+async function checkAgentsRoundTrip(manifest, skill, scope, errors) {
+	const rulesDir = path.join(process.cwd(), skill.dir, skill.rulesDir);
+	const agentsPath = path.join(process.cwd(), skill.dir, skill.agentsFile);
+
+	let committed;
+	try {
+		committed = await fs.readFile(agentsPath, 'utf-8');
+	} catch {
+		errors.push(`[${scope}] ${skill.agentsFile} is missing`);
+		return;
 	}
 
-	return errors;
+	const bodies = new Map();
+	for (const entry of manifest.rules) {
+		try {
+			const raw = await fs.readFile(path.join(rulesDir, `${entry.rule}.md`), 'utf-8');
+			bodies.set(entry.rule, bodyOf(raw));
+		} catch {
+			return; // missing rule file already reported in checkRules
+		}
+	}
+
+	const assembled = assembleAgentsMd(manifest, (slug) => bodies.get(slug), { lead: AGENTS_LEAD });
+	let expected;
+	try {
+		expected = oxfmtString(assembled);
+	} catch (err) {
+		errors.push(`[${scope}] could not run oxfmt for AGENTS.md round-trip: ${err.message}`);
+		return;
+	}
+
+	if (expected.trim() !== committed.trim()) {
+		errors.push(
+			`[${scope}] ${skill.agentsFile} is not in sync with the rules (run \`npm run generate\` to regenerate; do not hand-edit ${skill.agentsFile})`,
+		);
+	}
 }
 
 // ===========================================================================
@@ -396,56 +339,42 @@ async function reconcileManifestAndFrontmatter(manifest, skill, scope) {
 // ===========================================================================
 
 async function main() {
-	let totalErrors = 0;
+	const args = parseArgs(process.argv.slice(2));
+	const docsBuildDir = args.docsPath ? path.join(path.resolve(args.docsPath), 'build') : null;
+	if (docsBuildDir && !fsSync.existsSync(docsBuildDir)) {
+		console.error(`--docs-path given but ${docsBuildDir} does not exist`);
+		process.exit(1);
+	}
 
+	const errors = [];
 	for (const skill of SKILLS) {
 		const scope = skill.dir;
-		const manifestPath = path.join(process.cwd(), skill.dir, skill.manifestFile);
-
-		let rawManifest;
-		try {
-			rawManifest = await fs.readFile(manifestPath, 'utf-8');
-		} catch (err) {
-			console.error(`[${scope}] Cannot read manifest at ${manifestPath}: ${err.message}`);
-			totalErrors++;
-			continue;
-		}
-
 		let manifest;
 		try {
-			manifest = yaml.load(rawManifest);
+			manifest = await loadManifest(skill);
 		} catch (err) {
-			console.error(`[${scope}] Failed to parse manifest YAML: ${err.message}`);
-			totalErrors++;
+			errors.push(`[${scope}] cannot load manifest: ${err.message}`);
 			continue;
 		}
 
-		// Layer 2.
-		const lintErrors = lintManifest(manifest, scope);
-		for (const err of lintErrors) {
-			console.error(err.message);
-		}
-		totalErrors += lintErrors.length;
-
-		// If the manifest itself is malformed at the root we can't reconcile.
-		if (lintErrors.length > 0 && !Array.isArray(manifest?.rules)) {
-			continue;
-		}
-
-		// Layer 3.
-		const reconcileErrors = await reconcileManifestAndFrontmatter(manifest, skill, scope);
-		for (const err of reconcileErrors) {
-			console.error(err.message);
-		}
-		totalErrors += reconcileErrors.length;
+		if (!lintManifest(manifest, scope, errors)) continue; // can't reconcile a broken manifest
+		await checkRules(manifest, skill, scope, docsBuildDir, errors);
+		await checkAgentsRoundTrip(manifest, skill, scope, errors);
 	}
 
-	if (totalErrors > 0) {
-		console.error(`\n✗ validate-generated: ${totalErrors} error${totalErrors === 1 ? '' : 's'}`);
+	if (errors.length > 0) {
+		for (const e of errors) console.error(e);
+		console.error(
+			`\n✗ validate-generated: ${errors.length} error${errors.length === 1 ? '' : 's'}`,
+		);
 		process.exit(1);
-	} else {
-		console.log('✓ validate-generated: manifest and frontmatter reconciliation passed');
 	}
+	const docsNote = docsBuildDir
+		? ''
+		: ' (source-exists / byte-identical checks skipped — no --docs-path)';
+	console.log(
+		`✓ validate-generated: manifest, frontmatter, and AGENTS.md checks passed${docsNote}`,
+	);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Phase 2 (skills side) of the docs-driven skill generation plan

The full skills-side pipeline: the generator (proven end-to-end on `vector-indexing`) **and** the CI workflow that runs it. Originally split into 2a/2b PRs; consolidated here since the workflow is a single file. The companion docs-repo dispatch hook is a separate PR — [HarperFast/documentation#499](https://github.com/HarperFast/documentation/pull/499) — since it's a different repo.

**Offline-first:** the generator reads docs from a local built checkout (`<docs>/build/`), never over the network.

## Generation tooling (`scripts/generation/`)

| File | Role |
|---|---|
| `lib/manifest.mjs` | Shared manifest loading, category labels, schema enums, source normalization |
| `lib/sources.mjs` | Resolve sources against `<docs>/build/<path>`, slice a section by heading, compute the input hash for the no-op skip |
| `lib/llm.mjs` | Anthropic SDK call for `generate` mode — `claude-sonnet-4-6` @ temp 0, prompt-cached system prompt, `GENERATE_MODEL` override |
| `lib/render.mjs` | Compose rule files + deterministic AGENTS.md assembly |
| `templates/{system-prompt,rule-template}.md` | The generation prompt + required rule structure |
| `generate-rules.mjs` | Orchestration: resolve → hash → skip-check → produce → write → format → reassemble AGENTS.md (`--docs-path`, `--rule`, `--force`) |

## Validator — Layers 2–4

`validate-generated.mjs` rewritten on the shared libs. Layer 2 (manifest lint) + Layer 3 (manifest↔frontmatter reconciliation) preserved; Layer 4 added: `must_cover` assertions, byte-identical (direct, needs `--docs-path`), min body length, no-leaked-MDX (code-stripped), source-exists (needs `--docs-path`), and **AGENTS.md round-trip equality**. Docs-dependent checks skip with a note when `--docs-path` is absent.

## CI workflow (`.github/workflows/generate.yaml`)

- **Triggers:** `repository_dispatch` (`docs-updated`, from the docs repo), weekly cron safety net, manual `workflow_dispatch`.
- **Flow:** check out skills + docs as siblings → `npm ci && npm run build` in docs → `npm run generate --docs-path ../documentation` → validate (incl. `--docs-path`) → open/update a single rolling `auto/docs-sync` PR.
- **Auth:** GitHub App (`harper-skills-sync`), short-lived token via `actions/create-github-app-token@v3.2.0` (SHA-pinned). The App token on the checkout + PR makes the auto-PR trigger CI. `documentation` is public, so no token needed to read it.

## Content + wiring

- `package.json`: `generate` script + `@anthropic-ai/sdk` **devDep** (tooling isn't shipped — `files` only includes `dist` + `harper-best-practices`).
- Manifest: `vector-indexing` → `mode: generate` with `sources` + `must_cover` + a cross-link.
- `vector-indexing.md`: regenerated from `reference/v5/database/schema.md#Vector Indexing`.
- `AGENTS.md`: now a generated artifact (round-trip-enforced).
- `.gitignore`: add `.env`.

## The model/temperature decision

`claude-sonnet-4-6` + `temperature: 0` rather than Opus 4.7: Opus 4.7 removed `temperature`, and this mechanical recurring rewrite values determinism + cost over frontier reasoning. One-line `GENERATE_MODEL` override.

## Verification

```
$ npm run generate -- --docs-path ../documentation
✓ vector-indexing (generate)        # 1464 tokens in / 991 out on sonnet-4-6
$ npm run generate -- --docs-path ../documentation   # re-run → no-op skip
Generation complete: 0 regenerated, 1 unchanged, 19 synthesized (skipped).
$ npm run validate
✓ All skills and rules validated successfully
✓ validate-generated: manifest, frontmatter, and AGENTS.md checks passed
```

## Secrets to provision (skills repo)

| Secret | For | If absent |
|---|---|---|
| `ANTHROPIC_API_KEY` | `mode: generate` | **Required** |
| `SKILLS_SYNC_APP_ID` / `SKILLS_SYNC_APP_PRIVATE_KEY` | App auth for the auto-PR | Workflow can't open the PR |

## Reviewer notes

- **AGENTS.md is now generated** (was hand-authored); the round-trip validator keeps it derived. Diff it in Files.
- The other 19 rules stay `mode: synthesized` — they migrate per-rule in Phase 3/4.
- Smoke-test after merge via **Actions → Generate Rules from Docs → Run workflow** once `ANTHROPIC_API_KEY` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)