### PR TITLE
feat: phase 4 — migrate 3 rules to mode:generate, add failure-issue observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your key.
+# Required for: npm run generate (rule generation via LLM)
+ANTHROPIC_API_KEY=

--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -14,6 +14,17 @@ After cloning, install dependencies and (optionally) set up git hooks:
 npm install
 ```
 
+## Environment variables
+
+Running the rule generator (`npm run generate`) requires an Anthropic API key. Copy the example file and fill in your key:
+
+```bash
+cp .env.example .env
+# then edit .env and set ANTHROPIC_API_KEY
+```
+
+The `.env` file is gitignored and only needed locally. CI reads the key from repository secrets (`ANTHROPIC_API_KEY`).
+
 ## Development workflow
 
 - Format source files: `npm run format` — formats in place using oxfmt. Run this before committing if you've edited markdown, JSON, or other formatter-managed files.

--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -1,14 +1,14 @@
 # Contributing to Harper Skills
 
-Thank you for your interest in contributing! This document explains how to set up your environment, make changes safely, and submit high‑quality pull requests.
+Thank you for your interest in contributing! This document explains how the repo works, what each piece does, and how to make changes confidently.
 
 ## Prerequisites
 
-- Node.js (see .nvmrc file)
+- Node.js (see `.nvmrc`)
 - npm (use the version pinned in `.nvmrc`)
 - Git
 
-After cloning, install dependencies and (optionally) set up git hooks:
+After cloning, install dependencies:
 
 ```bash
 npm install
@@ -25,89 +25,293 @@ cp .env.example .env
 
 The `.env` file is gitignored and only needed locally. CI reads the key from repository secrets (`ANTHROPIC_API_KEY`).
 
-## Development workflow
+## Repo anatomy
 
-- Format source files: `npm run format` — formats in place using oxfmt. Run this before committing if you've edited markdown, JSON, or other formatter-managed files.
-- Check formatting without writing: `npm run format:check` — exits non-zero if any file would be changed by `npm run format`. This is the gate enforced by CI.
-- Validate everything: `npm run validate` — runs `format:check`, then `build`, then both skill validators (`validate-skills.mjs` for the legacy schema checks, `validate-generated.mjs` for manifest ↔ frontmatter reconciliation defined under `scripts/generation/`).
+Every file and directory at a glance — nothing is skipped because "it's obvious."
 
-The pipeline is intentionally ordered so `format:check` runs first. CI will fail loudly on formatting drift rather than silently auto-fixing it.
-
-## Creating Skills
-
-Skills are directories containing a `SKILL.md` file with YAML frontmatter:
-
-```markdown
----
-name: my-skill
-description: What this skill does and when to use it
----
-
-# My Skill
-
-Instructions for the agent to follow when this skill is activated.
-
-## When to Use
-
-Describe the scenarios where this skill should be used.
-
-## Steps
-
-1. First, do this
-2. Then, do that
+```
+/
+├── harper-best-practices/       # The harper-best-practices skill
+│   ├── SKILL.md                 # Skill metadata + generated rule index
+│   ├── AGENTS.md                # Compiled flat view of all rules (derived)
+│   ├── rules.manifest.yaml      # Source of truth for rule taxonomy (human-owned)
+│   └── rules/                   # One .md file per rule
+│       └── <slug>.md
+├── scripts/
+│   ├── build.mjs                # Builds the npm package (dist/)
+│   ├── validate-skills.mjs      # Layer 1 validator: basic SKILL.md / rule schema
+│   └── generation/
+│       ├── generate-rules.mjs   # Rule generator (entry point for npm run generate)
+│       ├── validate-generated.mjs  # Layers 2–4 validator: manifest lint,
+│       │                           # frontmatter reconciliation, body checks
+│       ├── lib/
+│       │   ├── llm.mjs          # Anthropic API call + retry logic
+│       │   ├── manifest.mjs     # Manifest loading + normalisation helpers
+│       │   ├── render.mjs       # AGENTS.md + SKILL.md index assembly
+│       │   └── sources.mjs      # Source resolution, section slicing, hashing
+│       └── templates/
+│           ├── system-prompt.md # LLM system prompt for mode:generate rules
+│           └── rule-template.md # Output template the LLM fills in
+├── docs/
+│   └── plans/                   # Planning documents (not steady-state docs)
+├── dist/                        # Built output (gitignored, produced by npm run build)
+│   ├── index.js
+│   └── index.d.ts
+├── .github/
+│   ├── CONTRIBUTING.MD          # This file
+│   └── workflows/
+│       ├── generate.yaml        # Auto-sync: regenerates rules when docs change
+│       ├── release.yaml         # semantic-release on merge to main
+│       ├── validate-skills.yml  # PR gate: runs npm run validate
+│       └── verify-commits.yaml  # PR gate: runs commitlint
+├── .env.example                 # Template for local environment variables
+├── .nvmrc                       # Node.js version pin
+├── .oxfmtrc.json                # oxfmt formatter config
+├── commitlint.config.cjs        # Conventional Commits enforcement
+├── package.json                 # npm package manifest + scripts
+├── release.config.js            # semantic-release configuration
+├── renovate.json                # Automated dependency update config
+└── AGENTS.md                    # Repo-level onboarding for agents/humans
+                                 # (top-level — distinct from the per-skill one)
 ```
 
-### Required Fields
+### Key files in detail
 
-- `name`: Unique identifier (lowercase, hyphens allowed)
-- `description`: Brief explanation of what the skill does
+**`harper-best-practices/rules.manifest.yaml`** is the declarative source of truth for the entire skill. It lists every rule, what docs feed it, how the body is generated, and what the output must contain. Humans edit this file; the generator reads it. If the manifest and a rule file disagree, validation fails and tells you to regenerate.
 
-### Required Sections
+**`harper-best-practices/rules/<slug>.md`** is a single rule file. It begins with YAML frontmatter:
 
-- `## When to Use`: Scenarios where the skill applies.
-- `## Steps`: A numbered list of actions for the agent.
+```yaml
+---
+name: vector-indexing
+description: How to enable and query vector indexes for similarity search in Harper.
+metadata:
+  mode: generate            # generate | direct | synthesized
+  sources:
+    - reference/v5/database/schema.md#Vector Indexing
+  sourceCommit: a1b2c3d4   # docs SHA at last generation
+  inputHash: 9f8e7d6c      # hash of resolved source content at last generation
+---
+```
 
-### Optional Fields
+- `name` and `description` are written by the generator from the manifest — do not edit them directly; edit the manifest instead.
+- `metadata.mode` records how the body was produced.
+- `metadata.sourceCommit` / `metadata.inputHash` provide inspectable provenance and let the generator skip no-op regenerations.
 
-- `metadata.internal`: Set to `true` to hide the skill from normal discovery.
+**`harper-best-practices/SKILL.md`** contains human-authored prose (trigger description, examples, how-it-works) plus a generated rule-index table between two sentinel comments (`<!-- BEGIN GENERATED INDEX -->` / `<!-- END GENERATED INDEX -->`). Do not hand-edit between the sentinels — the generator owns that region and will overwrite it.
+
+**`harper-best-practices/AGENTS.md`** is assembled by the generator by concatenating all rule bodies under category headers, in manifest order. Do not hand-edit it; run `npm run generate` to rebuild it.
+
+**Top-level `AGENTS.md`** is a separate, hand-authored file — it is repo-level onboarding for any agent (or human) opening this repository. It is not managed by the generator.
+
+**`dist/`** is produced by `npm run build`. It exports a map of skills keyed by name for npm consumers. It is gitignored; CI builds and publishes it via semantic-release.
+
+---
+
+## Concepts
+
+### Rule
+
+An atomic instruction file covering one topic (e.g., `vector-indexing`, `caching`). Each rule answers: "what should the agent do for this specific subtask?" Rules live in `<skill-dir>/rules/<slug>.md` and are loaded on demand.
+
+### Skill
+
+A coherent bundle of rules plus trigger metadata and navigation guidance for a domain. The skill answers: "what is this bundle for, and how does the agent navigate it?" Today there is one skill (`harper-best-practices`); future skills would be sibling directories (`harper-fabric-ops/`, etc.).
+
+### Manifest
+
+`rules.manifest.yaml` — the human-owned map from rules to their docs sources, generation mode, and output assertions. The single source of truth for rule taxonomy. Validation enforces that every rule file matches it exactly.
+
+### Generation modes
+
+Each manifest entry declares a `mode` that controls how the rule body is produced:
+
+| Mode | What it means | LLM call? |
+|---|---|---|
+| `generate` | Body is rewritten by an LLM from the declared `sources[]` under a fixed template. Use when the source is long, spans multiple files, or benefits from agent-tuned prose. | Yes |
+| `direct` | Body is the verbatim flat-markdown of `sources[]`. Use when the source is already concise and byte-level auditability matters. | No |
+| `synthesized` | Body is hand-authored. Use when there is no canonical docs source. The generator never touches it. | No |
+
+Switching between `generate` and `direct` is a one-line manifest edit plus a regenerate. Neither mode is universally better — the right choice is per-rule based on what serves the agent.
+
+### AGENTS.md (compiled)
+
+The per-skill `AGENTS.md` is a flat concatenation of all rule bodies in manifest order under category headers. It exists for consumers that want one file instead of many individual rule files. The generator rebuilds it on every full run.
+
+---
+
+## The generation pipeline
+
+When docs change (or on a weekly safety-net cron), `.github/workflows/generate.yaml` runs:
+
+1. **Checks out `HarperFast/documentation`** at the triggering SHA and runs `npm ci && npm run build` in it. This produces per-route flat-markdown files under `documentation/build/` via the `@signalwire/docusaurus-plugin-llms-txt` Docusaurus plugin.
+
+2. **Reads `rules.manifest.yaml`** and iterates over every non-synthesized rule.
+
+3. **Resolves sources** — for each `sources[].path`, reads the corresponding file from `documentation/build/`. If `sources[].section` is set, slices out that heading's content subtree. Concatenates sources in manifest order.
+
+4. **Computes an input hash** (SHA-256 of resolved content). Compares against `metadata.inputHash` in the existing rule file. If they match, the rule is already current — skip.
+
+5. **Produces the body** — `mode: generate` calls Claude under the rule template; `mode: direct` copies the resolved content verbatim.
+
+6. **Writes the rule file** with updated frontmatter (`sourceCommit`, `inputHash`, `sources` snapshot).
+
+7. **Reassembles `AGENTS.md`** from the formatted rule bodies.
+
+8. **Splices the generated index** into `SKILL.md` between the sentinel comments.
+
+9. **Validates** — runs `validate-generated.mjs` (manifest lint, frontmatter reconciliation, must-cover assertions, AGENTS.md round-trip). Failures open a GitHub issue pointing at the failing run.
+
+10. **Opens a sync PR** if anything changed — branch `auto/docs-sync`, title `docs: regenerate rules from documentation@<sha>`. One rolling branch; re-triggering before merge force-updates the same PR.
+
+This flow is **offline-first**: no network calls to `docs.harperdb.io`. Everything reads from the local docs build.
+
+---
+
+## Common tasks
+
+### How do I add a new rule?
+
+1. Add an entry to `harper-best-practices/rules.manifest.yaml`:
+
+   ```yaml
+   - rule: my-new-rule
+     description: One sentence the agent uses to decide when to load this rule.
+     category: api          # schema | api | logic | ops
+     priority: 2            # 1–4 (determines AGENTS.md category ordering)
+     order: 5               # position within the category
+     mode: generate
+     sources:
+       - path: reference/v5/rest/my-page.md
+         section: 'Relevant Section Heading'
+         role: primary
+     must_cover:
+       - 'key term that must appear in the generated body'
+   ```
+
+2. Run the generator locally (you need the docs repo checked out and built):
+
+   ```bash
+   npm run generate -- --docs-path ../documentation --rule my-new-rule
+   ```
+
+   Omit `--rule` to regenerate all changed rules. Use `--force` to regenerate even when the input hash is unchanged.
+
+3. Review the generated `harper-best-practices/rules/my-new-rule.md`, then open a PR with a `feat:` commit.
+
+For `mode: synthesized` (no docs source), omit `sources[]` and `must_cover`, write the rule body by hand, and open the PR.
+
+### How do I change which docs feed a rule?
+
+1. Edit `sources[]` in the manifest entry — update `path`, `section`, or add/remove entries.
+
+2. Regenerate:
+
+   ```bash
+   npm run generate -- --docs-path ../documentation --rule <slug>
+   ```
+
+3. Review the diff and open a PR.
+
+### How do I switch a rule's mode?
+
+Change `mode` in the manifest, add or remove `sources[]` and `must_cover` as required by the new mode, then regenerate. The generator overwrites the body and frontmatter.
+
+### How do I add a new skill?
+
+1. Create a new top-level directory, e.g. `harper-fabric-ops/`, with:
+   - `SKILL.md` — skill metadata + sentinel comments for the generated index
+   - `AGENTS.md` — initially empty; the generator fills it
+   - `rules.manifest.yaml` — the new skill's manifest
+   - `rules/` — rule files
+
+2. The existing `generate.yaml` workflow processes every skill directory automatically — no per-skill workflow changes needed.
+
+3. `dist/index.js` will export the new skill after `npm run build`.
+
+### An auto-sync PR looks wrong — what do I do?
+
+Check what changed in the docs at the linked commit SHA. Common cases:
+
+- **Wrong content**: a source section may have changed. Update `sources[].section` or `sources[].path` in the manifest and regenerate.
+- **Missing key term**: add it to `must_cover` if it should always be present, then regenerate.
+- **Good content, but needs stable wording**: switch the rule to `mode: synthesized` and hand-author the body. The generator will never touch it again.
+
+Close the auto-PR without merging, fix the manifest on a new branch, and open a corrective PR against `main`. The next auto-sync will be a no-op once your fix merges.
+
+---
+
+## What's automated vs. what's manual
+
+> **Humans own the rule taxonomy. Automation owns keeping rule bodies in sync with their declared sources.**
+
+| What | Who does it |
+|---|---|
+| Decide which rules exist | Human PR |
+| Decide what docs feed each rule | Human PR (manifest edit) |
+| Decide the generation mode per rule | Human PR (manifest edit) |
+| Write `synthesized` rule bodies | Human |
+| Regenerate `generate` / `direct` bodies when docs change | Automated (dispatch + cron) |
+| Reassemble AGENTS.md and SKILL.md index | Automated (every generation run) |
+| Open sync PRs | Automated (`generate.yaml`) |
+| Open failure issues when generation breaks | Automated (`generate.yaml`) |
+| Review and merge sync PRs | Human |
+| Publish new npm versions | Automated (semantic-release on merge to main) |
+
+When a docs structural change breaks automation (renamed file, renamed heading), the workflow opens a GitHub issue. The fix is always the same shape: update the manifest, regenerate locally, open a PR.
+
+---
+
+## Development workflow
+
+- **Format**: `npm run format` — formats files in place using oxfmt.
+- **Format check**: `npm run format:check` — exits non-zero if any file would be reformatted. CI gate.
+- **Build**: `npm run build` — compiles `dist/`.
+- **Validate**: `npm run validate` — runs `format:check` + `build` + both validators. Run this before pushing.
+- **Validate with docs**: add `&& node scripts/generation/validate-generated.mjs --docs-path ../documentation` for the full suite including source-exists and byte-identical checks.
+
+The pipeline is ordered so `format:check` runs first. CI fails loudly on formatting drift rather than silently auto-fixing it.
+
+---
 
 ## Commit conventions
 
-We use Conventional Commits and commitlint to keep history clean and meaningful.
-
-Examples:
+We use [Conventional Commits](https://www.conventionalcommits.org/) enforced by commitlint.
 
 ```
-feat: add database browser filters
-fix: normalize column widths in table view
-chore(ci): update workflow names
+feat: add streaming-uploads rule
+fix: correct must_cover assertion for querying-rest-apis
+chore(ci): pin generate.yaml action SHAs
+docs: update CONTRIBUTING with generation pipeline
 ```
 
-- Lint your commit: `npm run commitlint --edit`
-- If you want a commit-msg hook locally, you can add one (optional):
-  ```bash
-  # if a .husky directory is present in your clone
-  npx husky add .husky/commit-msg 'npm commitlint --edit "$1"'
-  ```
+Useful types: `feat`, `fix`, `perf`, `refactor`, `chore`, `docs`, `style`, `test`, `build`, `ci`, `revert`.
 
-Useful types include: feat, fix, perf, refactor, chore, docs, style, test, build, ci, revert.
+Semantic-release maps `feat` → minor version bump and `fix` / `perf` → patch.
+
+---
 
 ## Branching and pull requests
 
-- Create feature branches from the main development branch.
-- Keep PRs focused and reasonably small.
-- Ensure `npm run validate` passes before requesting review.
-- Use descriptive PR titles that align with Conventional Commits when possible.
+- Create feature branches from `main`.
+- Keep PRs focused — one rule migration, one workflow change, etc.
+- `npm run validate` must pass before requesting review.
+- Auto-sync PRs (`auto/docs-sync`) are reviewed like any rule change — read the generated diff, check that the agent-facing prose is clean and accurate, and verify `must_cover` terms are present.
 
 Releases are automated from the `main` branch via semantic-release.
 
+---
+
 ## Code review guidelines
 
-- Prefer clear, readable code over “clever” code.
-- Add comments where intent isn’t obvious.
+- For generated rule bodies: verify the prose reflects the source intent, not just that it satisfies `must_cover`.
+- Prefer concise, action-oriented agent instructions over comprehensive coverage. Rules are loaded on demand; brevity helps.
+- Add comments in manifest entries or scripts where intent isn't obvious.
 - Avoid introducing unused dependencies.
 - Keep changes backward compatible when feasible.
 
+---
+
 ## Questions
 
-If you’re unsure about anything, open a draft PR early or start a discussion. We’re happy to help get you unblocked quickly.
+If you're unsure about anything, open a draft PR early or start a discussion. We're happy to help get you unblocked quickly.

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: generate-rules
@@ -93,6 +94,44 @@ jobs:
           npm run build
           node scripts/validate-skills.mjs
           node scripts/generation/validate-generated.mjs --docs-path ../documentation
+
+      - name: Report generation failure
+        if: failure()
+        working-directory: skills
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          set -euo pipefail
+          # Resolve the actual docs commit SHA (falls back to the ref if the
+          # documentation checkout failed before we could read HEAD).
+          DOCS_SHA=$(git -C ../documentation rev-parse HEAD 2>/dev/null || echo "${{ steps.docsref.outputs.ref }}")
+          SHORT="${DOCS_SHA:0:7}"
+          TITLE="Auto-sync generation failure (${SHORT})"
+
+          # Idempotent by docs SHA: if an open issue for this SHA already
+          # exists, add a comment rather than opening a duplicate.
+          EXISTING=$(gh issue list --state open --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" 2>/dev/null | head -1 || echo "")
+
+          if [ -n "$EXISTING" ]; then
+            echo "Existing failure issue #${EXISTING} — appending comment."
+            gh issue comment "$EXISTING" --body \
+              "Generation failed again for \`${DOCS_SHA}\` at $(date -u +%Y-%m-%dT%H:%M:%SZ). Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          else
+            gh issue create \
+              --title "${TITLE}" \
+              --label "bug" \
+              --body "Auto-sync generation failed for docs SHA \`${DOCS_SHA}\`.
+
+          Opened automatically by \`.github/workflows/generate.yaml\`. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full error.
+
+          **Common causes and fixes (Story 4 in docs/plans/docs-driven-skills.md):**
+          - Source file renamed or moved — update \`sources[].path\` in \`rules.manifest.yaml\`.
+          - Section heading renamed or removed — update \`sources[].section\`.
+          - Must-cover assertion no longer in source — update \`must_cover\` or the section changed.
+
+          After fixing, regenerate locally (\`npm run generate -- --docs-path <docs>\`) and open a fix PR."
+          fi
 
       - name: Open or update sync PR
         working-directory: skills

--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -40,69 +40,152 @@ type ExamplePerson @table @export {
 }
 ```
 
-### 1.2 Schema Design & Tooling
+### 1.2 Schema Design and Tooling
 
-Harper uses GraphQL schemas to define database tables, relationships, and APIs. To ensure the best development experience for both humans and AI agents, it's important to understand the core directives and configure your project tooling correctly.
+Instructions for the agent to follow when designing Harper schemas, applying core directives, and configuring GraphQL tooling.
 
-#### Core Harper Directives
+#### When to Use
 
-Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harper/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
+Apply this rule when creating or modifying Harper schema files, configuring `graphqlSchema` in `config.yaml`, or deciding which directives to apply to tables and fields. Use it any time a component needs tables, indexes, primary keys, or exported endpoints defined.
 
-##### Table Definition
+#### How It Works
 
-- `@table`: Marks a GraphQL type as a Harper database table.
-- `@export`: Automatically generates REST and WebSocket APIs for the table.
-- `@table(expiration: Int)`: Configures a time-to-expire for records in the table (useful for caching).
+1. **Create a GraphQL schema file** with Harper-specific directives. Name it (e.g., `schema.graphql`) and place it in your component directory.
 
-##### Attribute Constraints & Indexing
+   ```graphql
+   type Dog @table {
+   	id: Long @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
 
-- `@primaryKey`: Specifies the unique identifier for the table.
-- `@indexed`: Creates a standard index on the field for faster lookups.
-- `@indexed(type: "HNSW", distance: "cosine" | "euclidean" | "dot")`: Creates a vector index for similarity search.
+   type Breed @table {
+   	id: Long @primaryKey
+   	name: String @indexed
+   }
+   ```
 
-##### Relationships
+2. **Register the schema in `config.yaml`** using the `graphqlSchema` plugin key:
 
-- `@relationship(from: String)`: Defines a relationship to another table. `from` specifies the local field holding the foreign key.
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   ```
 
-##### Authentication & Authorization
+   Both plugins and applications can specify schemas this way.
 
-- `@auth(role: String)`: Restricts access to a table or field based on user roles.
+3. **Mark every table type with `@table`**. The type name becomes the table name by default. Use optional arguments to override behavior:
 
-#### Configuring GraphQL Tooling
+   | Argument       | Type      | Default                       | Description                                                   |
+   | -------------- | --------- | ----------------------------- | ------------------------------------------------------------- |
+   | `table`        | `String`  | type name                     | Override the table name                                       |
+   | `database`     | `String`  | `"data"`                      | Database to place the table in                                |
+   | `expiration`   | `Int`     | —                             | Seconds until a record goes stale                             |
+   | `eviction`     | `Int`     | `0`                           | Additional seconds after `expiration` before physical removal |
+   | `scanInterval` | `Int`     | `(expiration + eviction) / 4` | Seconds between eviction scans                                |
+   | `replicate`    | `Boolean` | `true`                        | Enable replication of this table                              |
 
-To get the best IDE support (autocompletion, validation) and to help AI agents understand your schema context, you should create a `graphql.config.yml` file in your project root.
+4. **Designate a primary key on every table** using `@primaryKey`. Primary keys must be unique; duplicate-key inserts are rejected. If no key is provided on insert, Harper auto-generates one:
+   - `String` or `ID` → UUID string
+   - `Int`, `Long`, or `Any` → auto-incrementing integer
 
-This file tells GraphQL tools where to find Harper's built-in types and directives alongside your own schema files.
+   Prefer `Long` or `Any` for auto-generated numeric keys; `Int` is 32-bit and may be insufficient for large tables.
 
-##### Creating `graphql.config.yml`
+5. **Index fields that need fast querying** with `@indexed`. This is required for filtering by that attribute in REST queries, SQL, or NoSQL operations. If the field value is an array, each element is individually indexed.
 
-Create a file named `graphql.config.yml` in your project root with the following content:
+   ```graphql
+   type Product @table {
+   	id: Long @primaryKey
+   	category: String @indexed
+   	price: Float @indexed
+   }
+   ```
 
-```yaml
-schema:
-  - 'node_modules/harper/schema.graphql'
-  - 'schema.graphql'
-  - 'schemas/*.graphql'
+6. **Expose a table as an external resource endpoint** with `@export`. This makes the table accessible via REST, MQTT, and other interfaces. The optional `name` parameter sets the URL path segment; without it, the type name is used.
+
+   ```graphql
+   type MyTable @table @export(name: "my-table") {
+   	id: Long @primaryKey
+   }
+   ```
+
+7. **Restrict extra properties** with `@sealed` when records must not include attributes beyond those declared. By default, Harper allows additional properties.
+
+   ```graphql
+   type StrictRecord @table @sealed {
+   	id: Long @primaryKey
+   	name: String
+   }
+   ```
+
+8. **Configure expiration, eviction, and scan behavior** together when building caching tables. These three arguments control the full record lifecycle:
+   - `expiration` — record becomes stale; next request triggers a source fetch
+   - `eviction` — additional time after `expiration` before physical removal
+   - `scanInterval` — how often Harper scans for records to evict; clock-aligned, not startup-aligned
+
+#### Examples
+
+**Caching table with tuned expiration:**
+
+```graphql
+# Expire after 5 minutes, evict after 1 hour, scan every 10 minutes
+type WeatherCache @table(expiration: 300, eviction: 3300, scanInterval: 600) {
+	id: ID @primaryKey
+	temperature: Float
+}
 ```
 
-##### Why this is important:
+**Table in a named database with expiration and an indexed field:**
 
-1. **Shared Directives**: It includes `@table`, `@primaryKey`, etc., so they aren't marked as "unknown directives".
-2. **Context for Agents**: When an agent reads your project, seeing this config helps it locate the core Harper definitions, leading to more accurate code generation.
-3. **Consistency**: The `npm create harper@latest` command includes this by default. Manually adding it to existing projects ensures they follow the same standards.
-
-#### Example Project Structure
-
-A typical Harper project with proper schema tooling:
-
-```text
-my-harper-app/
-├── config.yaml
-├── graphql.config.yml
-├── package.json
-├── schema.graphql
-└── resources.js
+```graphql
+type Event @table(database: "analytics", expiration: 86400) {
+	id: Long @primaryKey
+	name: String @indexed
+}
 ```
+
+**Session cache with auto-expiry:**
+
+```graphql
+type Session @table(expiration: 3600) {
+	id: Long @primaryKey
+	userId: String
+}
+```
+
+**Table with audit timestamps:**
+
+```graphql
+type Order @table @export(name: "orders") {
+	id: Long @primaryKey
+	createdAt: Long @createdTime
+	updatedAt: Long @updatedTime
+	status: String @indexed
+}
+```
+
+**Overriding the table name and disabling replication:**
+
+```graphql
+type Product @table(table: "products") {
+	id: Long @primaryKey
+	name: String
+}
+
+type LocalRecord @table(replicate: false) {
+	id: Long @primaryKey
+	value: String
+}
+```
+
+#### Notes
+
+- Use unique `database` names in plugins and applications to avoid table naming collisions, since all tables default to the `"data"` database.
+- Eviction removes non-indexed record data but does **not** remove a record from its secondary indexes. Indexes remain functional for evicted records; Harper fetches the full record from the source on demand when a query matches an evicted record.
+- `scanInterval` is clock-aligned to the server's local timezone. The server's startup time does not affect when eviction runs.
+- If replication is disabled on a table and later re-enabled, it will not catch up on writes made while replication was disabled.
+- Null values are indexed by `@indexed` fields, enabling queries such as `GET /Product/?category=null`.
 
 ### 1.3 Defining Relationships
 
@@ -1138,33 +1221,59 @@ for await (const record of tables.Product.search({
 
 Be very careful when performing updates and deletions! You may be dealing with live production data. The wrong request to delete, without approval from a human, could be devastating to a business. Always use the proper approval process.
 
-### 3.4 TypeScript Type Stripping
+### 3.4 TypeScript Type Stripping in Harper
 
-Instructions for the agent to follow when using TypeScript in Harper.
+Instructions for the agent to run `.ts` files directly in Harper without a build step using Node.js's built-in type stripping.
 
 #### When to Use
 
-Use this skill when you want to write Harper Resources in TypeScript and have them execute directly in Node.js without an intermediate build or compilation step.
+Apply this rule when writing Harper resource files in TypeScript. Use it any time you need to reference `.ts` source files from `config.yaml` or import between local TypeScript modules in a Harper project.
 
 #### How It Works
 
-1. **Verify Node.js Version**: Ensure you are using Node.js v22.6.0 or higher.
-2. **Name Files with `.ts`**: Create your resource files in the `resources/` directory with a `.ts` extension.
-3. **Use TypeScript Syntax**: Write your resource classes using standard TypeScript (interfaces, types, etc.).
-   ```typescript
-   import { Resource } from 'harper';
-   export class MyResource extends Resource {
-   	async get(): Promise<{ message: string }> {
-   		return { message: 'Running TS directly!' };
-   	}
-   }
-   ```
-4. **Use Explicit Extensions in Imports**: When importing other local modules, include the `.ts` extension: `import { helper } from './helper.ts'`.
-5. **Configure `config.yaml`**: Ensure `jsResource` points to your `.ts` files:
+1. **Ensure Node.js version**: Require Node.js 22.6 or later. Type stripping is unavailable on earlier versions.
+
+2. **Point `jsResource` at `.ts` files**: The `jsResource` plugin loads both `.js` and `.ts` files. Set its `files` glob in `config.yaml` to target your `.ts` source files:
+
    ```yaml
    jsResource:
      files: 'resources/*.ts'
    ```
+
+3. **Use explicit `.ts` extensions in local imports**: Node's loader does not resolve `'./helper'` to `'./helper.ts'`, so always include the full extension:
+
+   ```typescript
+   import { helper } from './helper.ts';
+   ```
+
+4. **Stay within type-stripping limits**: Only type annotations and declarations are removed. Do not use enums with runtime values, namespaces with runtime semantics, or any other features that require code transformation beyond type stripping.
+
+#### Examples
+
+A complete Harper resource written in TypeScript, using imports from the `harper` package:
+
+```typescript
+import { type RequestTargetOrId, Resource, tables } from 'harper';
+
+export class MyResource extends Resource {
+	async get(target?: RequestTargetOrId): Promise<{ message: string }> {
+		return { message: 'Hello from TS' };
+	}
+}
+```
+
+Paired `config.yaml` entry loading the file via `jsResource`:
+
+```yaml
+jsResource:
+  files: 'resources/*.ts'
+```
+
+#### Notes
+
+- No build step or transpiler is required — Harper runs `.ts` files directly.
+- Type imports (e.g., `import { type RequestTargetOrId }`) from the `harper` package work as usual.
+- Unsupported TypeScript features include: enums with runtime values, namespaces with runtime semantics, and anything requiring code transformation beyond simple type stripping.
 
 ### 3.5 Caching External Data Sources in Harper
 
@@ -1456,48 +1565,133 @@ CLI_TARGET='YOUR_CLUSTER_URL'
 
 ### 4.3 Creating Harper Applications
 
-The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command initializes a project with a standard folder structure, essential configuration files, and basic schema definitions.
+Instructions for the agent to initialize and run a new Harper application using the CLI and configure its core files.
 
 #### When to Use
 
-Use this command when starting a new Harper application or adding a new Harper microservice to an existing architecture.
+Apply this rule when scaffolding a new Harper application from scratch, wiring up a table schema, or starting the local development server. Use it any time `schema.graphql` or `config.yaml` need to be created or modified to register a table and enable plugins.
 
-#### Commands
+#### How It Works
 
-Initialize a project using your preferred package manager:
+1. **Clone the starter repo**: Get the application template locally. If using a container, clone into the mounted `dev/` directory.
 
-##### NPM
+   ```bash
+   git clone https://github.com/HarperFast/create-your-first-application.git first-harper-app
+   ```
 
-```bash
-npm create harper@latest
+2. **Define a table in `schema.graphql`**: Open `schema.graphql` and declare a type with the `@table` directive. Use `@primaryKey` to designate the primary key field. Add typed fields using standard GraphQL scalar types (`String`, `Int`, `ID`, etc.).
+
+   ```graphql
+   type Dog @table {
+   	id: ID @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
+   ```
+
+3. **Register the schema in `config.yaml`**: Open `config.yaml` and configure the `graphqlSchema` plugin with a `files` property pointing to your schema file. This tells Harper to process the schema on startup.
+
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   ```
+
+4. **Start the development server**: From inside the application directory, run `harper dev`. This watches all files (except `node_modules`) and automatically restarts Harper worker threads when changes are detected.
+
+   ```bash
+   harper dev .
+   ```
+
+5. **Enable the REST API**: Add the `@export` directive to the table type in `schema.graphql`, then add `rest: true` to `config.yaml`.
+
+   `schema.graphql`:
+
+   ```graphql
+   type Dog @table @export {
+   	id: ID @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
+   ```
+
+   `config.yaml`:
+
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   rest: true
+   ```
+
+   After saving, `harper dev` restarts automatically. Confirm the REST plugin is active by checking the logs for:
+
+   ```
+   REST:               HTTP: 9926
+   ```
+
+#### Examples
+
+**Full `config.yaml` with REST enabled:**
+
+```yaml
+graphqlSchema:
+  files: 'schema.graphql'
+rest: true
 ```
 
-##### PNPM
+**Full `schema.graphql` with REST export:**
 
-```bash
-pnpm create harper@latest
+```graphql
+type Dog @table @export {
+	id: ID @primaryKey
+	name: String
+	breed: String
+	age: Int
+}
 ```
 
-##### Bun
+**Create a record via `PUT`:**
 
 ```bash
-bun create harper@latest
+curl 'http://localhost:9926/Dog/001' \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Harper",
+    "breed": "Black Labrador / Chow Mix",
+    "age": 5
+  }' \
+  -w "%{http_code}"
 ```
 
-#### Options
-
-You can specify the project name and template directly:
+**Read a record via `GET`:**
 
 ```bash
-npm create harper@latest my-app --template default
+curl -s 'http://localhost:9926/Dog/001' | jq
 ```
 
-#### Next Steps
+**Query records by attribute:**
 
-1. **Configure Environment**: Set up your `.env` file with local or cloud credentials.
-2. **Define Schema**: Modify `schema.graphql` to fit your application's data model.
-3. **Start Development**: Run `npm run dev` to start the local Harper instance.
-4. **Deploy**: Use `npm run deploy` to push your application to Harper Fabric.
+```bash
+curl -s 'http://localhost:9926/Dog/?age=5' | jq
+```
+
+#### Notes
+
+- `harper dev .` watches for file changes and restarts worker threads automatically. Use `harper run` instead when the main thread must also restart (the `dev` command does not restart the main thread).
+- Stop either process with SIGINT (`Ctrl+C`).
+- The `graphqlSchema` plugin is built-in; no additional dependency installation is required.
+- The `files` property in `config.yaml` accepts a glob pattern — a single filename or a broader pattern are both valid.
+- The `@table` directive marks a type as a database table. Without it, Harper treats the type as an arbitrary GraphQL type.
+- The REST API defaults to port `9926`. This value is configurable.
+- To deploy a local application to a running Harper instance without using `harper dev`, use:
+  ```bash
+  harper deploy \
+    project=<name> \
+    package=<path-to-project> \
+    restart=true
+  ```
 
 ### 4.4 Serving Web Content
 

--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -1565,133 +1565,51 @@ CLI_TARGET='YOUR_CLUSTER_URL'
 
 ### 4.3 Creating Harper Applications
 
-Instructions for the agent to initialize and run a new Harper application using the CLI and configure its core files.
+The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command
+initializes a project with a standard folder structure, essential configuration files, and basic
+schema definitions.
 
 #### When to Use
 
-Apply this rule when scaffolding a new Harper application from scratch, wiring up a table schema, or starting the local development server. Use it any time `schema.graphql` or `config.yaml` need to be created or modified to register a table and enable plugins.
+Use this command when starting a new Harper application or adding a new Harper microservice to an
+existing architecture.
 
-#### How It Works
+#### Commands
 
-1. **Clone the starter repo**: Get the application template locally. If using a container, clone into the mounted `dev/` directory.
+Initialize a project using your preferred package manager:
 
-   ```bash
-   git clone https://github.com/HarperFast/create-your-first-application.git first-harper-app
-   ```
-
-2. **Define a table in `schema.graphql`**: Open `schema.graphql` and declare a type with the `@table` directive. Use `@primaryKey` to designate the primary key field. Add typed fields using standard GraphQL scalar types (`String`, `Int`, `ID`, etc.).
-
-   ```graphql
-   type Dog @table {
-   	id: ID @primaryKey
-   	name: String
-   	breed: String
-   	age: Int
-   }
-   ```
-
-3. **Register the schema in `config.yaml`**: Open `config.yaml` and configure the `graphqlSchema` plugin with a `files` property pointing to your schema file. This tells Harper to process the schema on startup.
-
-   ```yaml
-   graphqlSchema:
-     files: 'schema.graphql'
-   ```
-
-4. **Start the development server**: From inside the application directory, run `harper dev`. This watches all files (except `node_modules`) and automatically restarts Harper worker threads when changes are detected.
-
-   ```bash
-   harper dev .
-   ```
-
-5. **Enable the REST API**: Add the `@export` directive to the table type in `schema.graphql`, then add `rest: true` to `config.yaml`.
-
-   `schema.graphql`:
-
-   ```graphql
-   type Dog @table @export {
-   	id: ID @primaryKey
-   	name: String
-   	breed: String
-   	age: Int
-   }
-   ```
-
-   `config.yaml`:
-
-   ```yaml
-   graphqlSchema:
-     files: 'schema.graphql'
-   rest: true
-   ```
-
-   After saving, `harper dev` restarts automatically. Confirm the REST plugin is active by checking the logs for:
-
-   ```
-   REST:               HTTP: 9926
-   ```
-
-#### Examples
-
-**Full `config.yaml` with REST enabled:**
-
-```yaml
-graphqlSchema:
-  files: 'schema.graphql'
-rest: true
-```
-
-**Full `schema.graphql` with REST export:**
-
-```graphql
-type Dog @table @export {
-	id: ID @primaryKey
-	name: String
-	breed: String
-	age: Int
-}
-```
-
-**Create a record via `PUT`:**
+##### NPM
 
 ```bash
-curl 'http://localhost:9926/Dog/001' \
-  -X PUT \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Harper",
-    "breed": "Black Labrador / Chow Mix",
-    "age": 5
-  }' \
-  -w "%{http_code}"
+npm create harper@latest
 ```
 
-**Read a record via `GET`:**
+##### PNPM
 
 ```bash
-curl -s 'http://localhost:9926/Dog/001' | jq
+pnpm create harper@latest
 ```
 
-**Query records by attribute:**
+##### Bun
 
 ```bash
-curl -s 'http://localhost:9926/Dog/?age=5' | jq
+bun create harper@latest
 ```
 
-#### Notes
+#### Options
 
-- `harper dev .` watches for file changes and restarts worker threads automatically. Use `harper run` instead when the main thread must also restart (the `dev` command does not restart the main thread).
-- Stop either process with SIGINT (`Ctrl+C`).
-- The `graphqlSchema` plugin is built-in; no additional dependency installation is required.
-- The `files` property in `config.yaml` accepts a glob pattern — a single filename or a broader pattern are both valid.
-- The `@table` directive marks a type as a database table. Without it, Harper treats the type as an arbitrary GraphQL type.
-- The REST API defaults to port `9926`. This value is configurable.
-- To deploy a local application to a running Harper instance without using `harper dev`, use:
-  ```bash
-  harper deploy \
-    project=<name> \
-    package=<path-to-project> \
-    restart=true
-  ```
+You can specify the project name and template directly:
+
+```bash
+npm create harper@latest my-app --template default
+```
+
+#### Next Steps
+
+1. **Configure Environment**: Set up your `.env` file with local or cloud credentials.
+2. **Define Schema**: Modify `schema.graphql` to fit your application's data model.
+3. **Start Development**: Run `npm run dev` to start the local Harper instance.
+4. **Deploy**: Use `npm run deploy` to push your application to Harper Fabric.
 
 ### 4.4 Serving Web Content
 
@@ -1908,3 +1826,91 @@ Tagged entries appear in `hdb.log` with the tag in the header:
 - `console.log` output is only forwarded to `hdb.log` when `logging.console: true` is explicitly set; it is not forwarded by default.
 - When logging to standard streams, run Harper in the foreground (`harper`, not `harper start`).
 - `TaggedLogger` is bound to the configured log level at creation time — always use `?.` on its methods.
+
+### 4.6 Load Environment Variables with loadEnv
+
+Instructions for the agent to follow when loading environment variables from `.env` files into a Harper application using the `loadEnv` plugin.
+
+#### When to Use
+
+Apply this rule when a Harper application needs to load secrets or configuration values from `.env` files into `process.env` at startup. Use it whenever you need to configure `loadEnv` in `config.yaml`, control load order, handle multiple files, or manage override behavior.
+
+#### How It Works
+
+1. **Declare `loadEnv` in `config.yaml`**: Add `loadEnv` to your `config.yaml` with a `files` key pointing to the `.env` file. `loadEnv` is built into Harper and does not need to be installed separately.
+
+   ```yaml
+   loadEnv:
+     files: '.env'
+   ```
+
+   This loads the specified file from the root of your component directory into `process.env`.
+
+2. **Place `loadEnv` first**: Always declare `loadEnv` before any other components in `config.yaml` so environment variables are available before dependent components start. Because Harper is single-process, variables loaded onto `process.env` are shared across all components.
+
+   ```yaml
+   # config.yaml — loadEnv must come first
+   loadEnv:
+     files: '.env'
+
+   rest: true
+
+   myApp:
+     files: './src/*.js'
+   ```
+
+3. **Control override behavior**: By default, existing shell or container environment variables take precedence over values in `.env` files. To force `.env` values to overwrite existing variables, set `override: true`.
+
+   ```yaml
+   loadEnv:
+     files: '.env'
+     override: true
+   ```
+
+4. **Load multiple files**: Provide a list of files or a glob pattern under `files`. Files are loaded in the order specified.
+   ```yaml
+   loadEnv:
+     files:
+       - '.env'
+       - '.env.local'
+   ```
+   Or using a glob pattern:
+   ```yaml
+   loadEnv:
+     files: 'env-vars/*'
+   ```
+
+#### Examples
+
+A complete `config.yaml` using `loadEnv` with multiple files and override enabled:
+
+```yaml
+# config.yaml — loadEnv must come first
+loadEnv:
+  files:
+    - '.env'
+    - '.env.local'
+  override: true
+
+rest: true
+
+myApp:
+  files: './src/*.js'
+```
+
+A minimal setup loading a single `.env` file:
+
+```yaml
+loadEnv:
+  files: '.env'
+
+myApp:
+  files: './src/*.js'
+```
+
+#### Notes
+
+- `loadEnv` is built into Harper — declare it in `config.yaml` only; do not install it as a separate package.
+- The `files` value accepts either a single string, a list of strings, or a glob pattern.
+- Without `override: true`, variables already present in the environment are never overwritten by values in `.env` files.
+- `process.env` is shared across all Harper components in the same process, so load order in `config.yaml` determines availability.

--- a/harper-best-practices/SKILL.md
+++ b/harper-best-practices/SKILL.md
@@ -82,6 +82,7 @@ See the concrete examples embedded in each rule subsection below (GraphQL schema
 - `creating-harper-apps` — How to initialize a new Harper application using the CLI.
 - `serving-web-content` — How to serve static files and integrated Vite/React applications in Harper.
 - `logging` — Best practices for logging in Harper, including console capture, the granular logger interface, and programmatic log retrieval.
+- `load-env` — How to load environment variables from .env files into a Harper application using the loadEnv plugin.
 
 <!-- END GENERATED INDEX -->
 

--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -9,8 +9,9 @@
 # Phase 3 flips 7 obvious 1:1 rules to mode: generate (automatic-apis,
 # querying-rest-apis, real-time-apps, checking-authentication, logging,
 # deploying-to-harper-fabric, caching). All others remain synthesized.
-# Phase 4 migrates schema-design-tooling, typescript-type-stripping, and
-# creating-harper-apps to mode: generate.
+# Phase 4 migrates schema-design-tooling and typescript-type-stripping to
+# mode: generate. creating-harper-apps stays synthesized pending dedicated
+# create-harper CLI documentation.
 
 rules:
   # ===========================================================================
@@ -259,18 +260,7 @@ rules:
     category: ops
     priority: 4
     order: 3
-    mode: generate
-    sources:
-      - path: learn/getting-started/create-your-first-application.md
-        role: primary
-      - path: reference/v5/components/applications.md
-        section: 'Local Development'
-        role: supplemental
-    must_cover:
-      - 'harper dev'
-      - 'config.yaml'
-      - 'schema.graphql'
-      - 'graphqlSchema'
+    mode: synthesized
 
   - rule: serving-web-content
     description: How to serve static files and integrated Vite/React applications in Harper.

--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -9,6 +9,8 @@
 # Phase 3 flips 7 obvious 1:1 rules to mode: generate (automatic-apis,
 # querying-rest-apis, real-time-apps, checking-authentication, logging,
 # deploying-to-harper-fabric, caching). All others remain synthesized.
+# Phase 4 migrates schema-design-tooling, typescript-type-stripping, and
+# creating-harper-apps to mode: generate.
 
 rules:
   # ===========================================================================
@@ -27,7 +29,23 @@ rules:
     category: schema
     priority: 1
     order: 2
-    mode: synthesized
+    mode: generate
+    sources:
+      - path: reference/v5/database/schema.md
+        section: 'Overview'
+        role: primary
+      - path: reference/v5/database/schema.md
+        section: 'Type Directives'
+        role: primary
+      - path: reference/v5/database/schema.md
+        section: 'Field Directives'
+        role: primary
+    must_cover:
+      - '@table'
+      - '@export'
+      - '@primaryKey'
+      - '@indexed'
+      - 'graphqlSchema'
 
   - rule: defining-relationships
     description: How to define and use relationships between tables in Harper using GraphQL.
@@ -178,7 +196,16 @@ rules:
     category: logic
     priority: 3
     order: 4
-    mode: synthesized
+    mode: generate
+    sources:
+      - path: reference/v5/components/javascript-environment.md
+        section: 'TypeScript Support'
+        role: primary
+    must_cover:
+      - '.ts'
+      - 'jsResource'
+      - 'Node.js 22.6'
+      - 'type stripping'
 
   - rule: caching
     description: How to implement integrated data caching in Harper from external sources.
@@ -232,7 +259,18 @@ rules:
     category: ops
     priority: 4
     order: 3
-    mode: synthesized
+    mode: generate
+    sources:
+      - path: learn/getting-started/create-your-first-application.md
+        role: primary
+      - path: reference/v5/components/applications.md
+        section: 'Local Development'
+        role: supplemental
+    must_cover:
+      - 'harper dev'
+      - 'config.yaml'
+      - 'schema.graphql'
+      - 'graphqlSchema'
 
   - rule: serving-web-content
     description: How to serve static files and integrated Vite/React applications in Harper.

--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -294,3 +294,19 @@ rules:
       - 'console.log'
       - 'logger'
       - 'withTag('
+
+  - rule: load-env
+    description: How to load environment variables from .env files into a Harper application using the loadEnv plugin.
+    category: ops
+    priority: 4
+    order: 6
+    mode: generate
+    sources:
+      - path: reference/v5/environment-variables/overview.md
+        role: primary
+    must_cover:
+      - 'loadEnv'
+      - 'files'
+      - 'process.env'
+      - 'override'
+      - 'config.yaml'

--- a/harper-best-practices/rules/creating-harper-apps.md
+++ b/harper-best-practices/rules/creating-harper-apps.md
@@ -2,140 +2,53 @@
 name: creating-harper-apps
 description: How to initialize a new Harper application using the CLI.
 metadata:
-  mode: generate
-  sources:
-    - learn/getting-started/create-your-first-application.md
-    - reference/v5/components/applications.md#Local Development
-  sourceCommit: b7fbddadd42eb4487190b650a9abc4bcfeef5819
-  inputHash: aae210b12cfdaf9f
+  mode: synthesized
 ---
 
 # Creating Harper Applications
 
-Instructions for the agent to initialize and run a new Harper application using the CLI and configure its core files.
+The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command
+initializes a project with a standard folder structure, essential configuration files, and basic
+schema definitions.
 
 ## When to Use
 
-Apply this rule when scaffolding a new Harper application from scratch, wiring up a table schema, or starting the local development server. Use it any time `schema.graphql` or `config.yaml` need to be created or modified to register a table and enable plugins.
+Use this command when starting a new Harper application or adding a new Harper microservice to an
+existing architecture.
 
-## How It Works
+## Commands
 
-1. **Clone the starter repo**: Get the application template locally. If using a container, clone into the mounted `dev/` directory.
+Initialize a project using your preferred package manager:
 
-   ```bash
-   git clone https://github.com/HarperFast/create-your-first-application.git first-harper-app
-   ```
-
-2. **Define a table in `schema.graphql`**: Open `schema.graphql` and declare a type with the `@table` directive. Use `@primaryKey` to designate the primary key field. Add typed fields using standard GraphQL scalar types (`String`, `Int`, `ID`, etc.).
-
-   ```graphql
-   type Dog @table {
-   	id: ID @primaryKey
-   	name: String
-   	breed: String
-   	age: Int
-   }
-   ```
-
-3. **Register the schema in `config.yaml`**: Open `config.yaml` and configure the `graphqlSchema` plugin with a `files` property pointing to your schema file. This tells Harper to process the schema on startup.
-
-   ```yaml
-   graphqlSchema:
-     files: 'schema.graphql'
-   ```
-
-4. **Start the development server**: From inside the application directory, run `harper dev`. This watches all files (except `node_modules`) and automatically restarts Harper worker threads when changes are detected.
-
-   ```bash
-   harper dev .
-   ```
-
-5. **Enable the REST API**: Add the `@export` directive to the table type in `schema.graphql`, then add `rest: true` to `config.yaml`.
-
-   `schema.graphql`:
-
-   ```graphql
-   type Dog @table @export {
-   	id: ID @primaryKey
-   	name: String
-   	breed: String
-   	age: Int
-   }
-   ```
-
-   `config.yaml`:
-
-   ```yaml
-   graphqlSchema:
-     files: 'schema.graphql'
-   rest: true
-   ```
-
-   After saving, `harper dev` restarts automatically. Confirm the REST plugin is active by checking the logs for:
-
-   ```
-   REST:               HTTP: 9926
-   ```
-
-## Examples
-
-**Full `config.yaml` with REST enabled:**
-
-```yaml
-graphqlSchema:
-  files: 'schema.graphql'
-rest: true
-```
-
-**Full `schema.graphql` with REST export:**
-
-```graphql
-type Dog @table @export {
-	id: ID @primaryKey
-	name: String
-	breed: String
-	age: Int
-}
-```
-
-**Create a record via `PUT`:**
+### NPM
 
 ```bash
-curl 'http://localhost:9926/Dog/001' \
-  -X PUT \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "Harper",
-    "breed": "Black Labrador / Chow Mix",
-    "age": 5
-  }' \
-  -w "%{http_code}"
+npm create harper@latest
 ```
 
-**Read a record via `GET`:**
+### PNPM
 
 ```bash
-curl -s 'http://localhost:9926/Dog/001' | jq
+pnpm create harper@latest
 ```
 
-**Query records by attribute:**
+### Bun
 
 ```bash
-curl -s 'http://localhost:9926/Dog/?age=5' | jq
+bun create harper@latest
 ```
 
-## Notes
+## Options
 
-- `harper dev .` watches for file changes and restarts worker threads automatically. Use `harper run` instead when the main thread must also restart (the `dev` command does not restart the main thread).
-- Stop either process with SIGINT (`Ctrl+C`).
-- The `graphqlSchema` plugin is built-in; no additional dependency installation is required.
-- The `files` property in `config.yaml` accepts a glob pattern — a single filename or a broader pattern are both valid.
-- The `@table` directive marks a type as a database table. Without it, Harper treats the type as an arbitrary GraphQL type.
-- The REST API defaults to port `9926`. This value is configurable.
-- To deploy a local application to a running Harper instance without using `harper dev`, use:
-  ```bash
-  harper deploy \
-    project=<name> \
-    package=<path-to-project> \
-    restart=true
-  ```
+You can specify the project name and template directly:
+
+```bash
+npm create harper@latest my-app --template default
+```
+
+## Next Steps
+
+1. **Configure Environment**: Set up your `.env` file with local or cloud credentials.
+2. **Define Schema**: Modify `schema.graphql` to fit your application's data model.
+3. **Start Development**: Run `npm run dev` to start the local Harper instance.
+4. **Deploy**: Use `npm run deploy` to push your application to Harper Fabric.

--- a/harper-best-practices/rules/creating-harper-apps.md
+++ b/harper-best-practices/rules/creating-harper-apps.md
@@ -2,50 +2,140 @@
 name: creating-harper-apps
 description: How to initialize a new Harper application using the CLI.
 metadata:
-  mode: synthesized
+  mode: generate
+  sources:
+    - learn/getting-started/create-your-first-application.md
+    - reference/v5/components/applications.md#Local Development
+  sourceCommit: b7fbddadd42eb4487190b650a9abc4bcfeef5819
+  inputHash: aae210b12cfdaf9f
 ---
 
 # Creating Harper Applications
 
-The fastest way to start a new Harper project is using the `create-harper` CLI tool. This command initializes a project with a standard folder structure, essential configuration files, and basic schema definitions.
+Instructions for the agent to initialize and run a new Harper application using the CLI and configure its core files.
 
 ## When to Use
 
-Use this command when starting a new Harper application or adding a new Harper microservice to an existing architecture.
+Apply this rule when scaffolding a new Harper application from scratch, wiring up a table schema, or starting the local development server. Use it any time `schema.graphql` or `config.yaml` need to be created or modified to register a table and enable plugins.
 
-## Commands
+## How It Works
 
-Initialize a project using your preferred package manager:
+1. **Clone the starter repo**: Get the application template locally. If using a container, clone into the mounted `dev/` directory.
 
-### NPM
+   ```bash
+   git clone https://github.com/HarperFast/create-your-first-application.git first-harper-app
+   ```
 
-```bash
-npm create harper@latest
+2. **Define a table in `schema.graphql`**: Open `schema.graphql` and declare a type with the `@table` directive. Use `@primaryKey` to designate the primary key field. Add typed fields using standard GraphQL scalar types (`String`, `Int`, `ID`, etc.).
+
+   ```graphql
+   type Dog @table {
+   	id: ID @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
+   ```
+
+3. **Register the schema in `config.yaml`**: Open `config.yaml` and configure the `graphqlSchema` plugin with a `files` property pointing to your schema file. This tells Harper to process the schema on startup.
+
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   ```
+
+4. **Start the development server**: From inside the application directory, run `harper dev`. This watches all files (except `node_modules`) and automatically restarts Harper worker threads when changes are detected.
+
+   ```bash
+   harper dev .
+   ```
+
+5. **Enable the REST API**: Add the `@export` directive to the table type in `schema.graphql`, then add `rest: true` to `config.yaml`.
+
+   `schema.graphql`:
+
+   ```graphql
+   type Dog @table @export {
+   	id: ID @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
+   ```
+
+   `config.yaml`:
+
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   rest: true
+   ```
+
+   After saving, `harper dev` restarts automatically. Confirm the REST plugin is active by checking the logs for:
+
+   ```
+   REST:               HTTP: 9926
+   ```
+
+## Examples
+
+**Full `config.yaml` with REST enabled:**
+
+```yaml
+graphqlSchema:
+  files: 'schema.graphql'
+rest: true
 ```
 
-### PNPM
+**Full `schema.graphql` with REST export:**
 
-```bash
-pnpm create harper@latest
+```graphql
+type Dog @table @export {
+	id: ID @primaryKey
+	name: String
+	breed: String
+	age: Int
+}
 ```
 
-### Bun
+**Create a record via `PUT`:**
 
 ```bash
-bun create harper@latest
+curl 'http://localhost:9926/Dog/001' \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Harper",
+    "breed": "Black Labrador / Chow Mix",
+    "age": 5
+  }' \
+  -w "%{http_code}"
 ```
 
-## Options
-
-You can specify the project name and template directly:
+**Read a record via `GET`:**
 
 ```bash
-npm create harper@latest my-app --template default
+curl -s 'http://localhost:9926/Dog/001' | jq
 ```
 
-## Next Steps
+**Query records by attribute:**
 
-1. **Configure Environment**: Set up your `.env` file with local or cloud credentials.
-2. **Define Schema**: Modify `schema.graphql` to fit your application's data model.
-3. **Start Development**: Run `npm run dev` to start the local Harper instance.
-4. **Deploy**: Use `npm run deploy` to push your application to Harper Fabric.
+```bash
+curl -s 'http://localhost:9926/Dog/?age=5' | jq
+```
+
+## Notes
+
+- `harper dev .` watches for file changes and restarts worker threads automatically. Use `harper run` instead when the main thread must also restart (the `dev` command does not restart the main thread).
+- Stop either process with SIGINT (`Ctrl+C`).
+- The `graphqlSchema` plugin is built-in; no additional dependency installation is required.
+- The `files` property in `config.yaml` accepts a glob pattern — a single filename or a broader pattern are both valid.
+- The `@table` directive marks a type as a database table. Without it, Harper treats the type as an arbitrary GraphQL type.
+- The REST API defaults to port `9926`. This value is configurable.
+- To deploy a local application to a running Harper instance without using `harper dev`, use:
+  ```bash
+  harper deploy \
+    project=<name> \
+    package=<path-to-project> \
+    restart=true
+  ```

--- a/harper-best-practices/rules/load-env.md
+++ b/harper-best-practices/rules/load-env.md
@@ -1,0 +1,100 @@
+---
+name: load-env
+description: >-
+  How to load environment variables from .env files into a Harper application
+  using the loadEnv plugin.
+metadata:
+  mode: generate
+  sources:
+    - reference/v5/environment-variables/overview.md
+  sourceCommit: b7fbddadd42eb4487190b650a9abc4bcfeef5819
+  inputHash: c73a0caf28a2b833
+---
+
+# Load Environment Variables with loadEnv
+
+Instructions for the agent to follow when loading environment variables from `.env` files into a Harper application using the `loadEnv` plugin.
+
+## When to Use
+
+Apply this rule when a Harper application needs to load secrets or configuration values from `.env` files into `process.env` at startup. Use it whenever you need to configure `loadEnv` in `config.yaml`, control load order, handle multiple files, or manage override behavior.
+
+## How It Works
+
+1. **Declare `loadEnv` in `config.yaml`**: Add `loadEnv` to your `config.yaml` with a `files` key pointing to the `.env` file. `loadEnv` is built into Harper and does not need to be installed separately.
+
+   ```yaml
+   loadEnv:
+     files: '.env'
+   ```
+
+   This loads the specified file from the root of your component directory into `process.env`.
+
+2. **Place `loadEnv` first**: Always declare `loadEnv` before any other components in `config.yaml` so environment variables are available before dependent components start. Because Harper is single-process, variables loaded onto `process.env` are shared across all components.
+
+   ```yaml
+   # config.yaml — loadEnv must come first
+   loadEnv:
+     files: '.env'
+
+   rest: true
+
+   myApp:
+     files: './src/*.js'
+   ```
+
+3. **Control override behavior**: By default, existing shell or container environment variables take precedence over values in `.env` files. To force `.env` values to overwrite existing variables, set `override: true`.
+
+   ```yaml
+   loadEnv:
+     files: '.env'
+     override: true
+   ```
+
+4. **Load multiple files**: Provide a list of files or a glob pattern under `files`. Files are loaded in the order specified.
+   ```yaml
+   loadEnv:
+     files:
+       - '.env'
+       - '.env.local'
+   ```
+   Or using a glob pattern:
+   ```yaml
+   loadEnv:
+     files: 'env-vars/*'
+   ```
+
+## Examples
+
+A complete `config.yaml` using `loadEnv` with multiple files and override enabled:
+
+```yaml
+# config.yaml — loadEnv must come first
+loadEnv:
+  files:
+    - '.env'
+    - '.env.local'
+  override: true
+
+rest: true
+
+myApp:
+  files: './src/*.js'
+```
+
+A minimal setup loading a single `.env` file:
+
+```yaml
+loadEnv:
+  files: '.env'
+
+myApp:
+  files: './src/*.js'
+```
+
+## Notes
+
+- `loadEnv` is built into Harper — declare it in `config.yaml` only; do not install it as a separate package.
+- The `files` value accepts either a single string, a list of strings, or a glob pattern.
+- Without `override: true`, variables already present in the environment are never overwritten by values in `.env` files.
+- `process.env` is shared across all Harper components in the same process, so load order in `config.yaml` determines availability.

--- a/harper-best-practices/rules/schema-design-tooling.md
+++ b/harper-best-practices/rules/schema-design-tooling.md
@@ -1,70 +1,161 @@
 ---
 name: schema-design-tooling
-description: Best practices for Harper schema design, including core directives and GraphQL tooling configuration.
+description: >-
+  Best practices for Harper schema design, including core directives and GraphQL
+  tooling configuration.
 metadata:
-  mode: synthesized
+  mode: generate
+  sources:
+    - reference/v5/database/schema.md#Overview
+    - reference/v5/database/schema.md#Type Directives
+    - reference/v5/database/schema.md#Field Directives
+  sourceCommit: b7fbddadd42eb4487190b650a9abc4bcfeef5819
+  inputHash: 4faa3baed7cfa854
 ---
 
-# Schema Design & Tooling
+# Schema Design and Tooling
 
-Harper uses GraphQL schemas to define database tables, relationships, and APIs. To ensure the best development experience for both humans and AI agents, it's important to understand the core directives and configure your project tooling correctly.
+Instructions for the agent to follow when designing Harper schemas, applying core directives, and configuring GraphQL tooling.
 
-## Core Harper Directives
+## When to Use
 
-Harper extends GraphQL with custom directives that define database behavior. These are typically defined in `node_modules/harper/schema.graphql`. If you don't have access to that file, here is a reference of the most important ones:
+Apply this rule when creating or modifying Harper schema files, configuring `graphqlSchema` in `config.yaml`, or deciding which directives to apply to tables and fields. Use it any time a component needs tables, indexes, primary keys, or exported endpoints defined.
 
-### Table Definition
+## How It Works
 
-- `@table`: Marks a GraphQL type as a Harper database table.
-- `@export`: Automatically generates REST and WebSocket APIs for the table.
-- `@table(expiration: Int)`: Configures a time-to-expire for records in the table (useful for caching).
+1. **Create a GraphQL schema file** with Harper-specific directives. Name it (e.g., `schema.graphql`) and place it in your component directory.
 
-### Attribute Constraints & Indexing
+   ```graphql
+   type Dog @table {
+   	id: Long @primaryKey
+   	name: String
+   	breed: String
+   	age: Int
+   }
 
-- `@primaryKey`: Specifies the unique identifier for the table.
-- `@indexed`: Creates a standard index on the field for faster lookups.
-- `@indexed(type: "HNSW", distance: "cosine" | "euclidean" | "dot")`: Creates a vector index for similarity search.
+   type Breed @table {
+   	id: Long @primaryKey
+   	name: String @indexed
+   }
+   ```
 
-### Relationships
+2. **Register the schema in `config.yaml`** using the `graphqlSchema` plugin key:
 
-- `@relationship(from: String)`: Defines a relationship to another table. `from` specifies the local field holding the foreign key.
+   ```yaml
+   graphqlSchema:
+     files: 'schema.graphql'
+   ```
 
-### Authentication & Authorization
+   Both plugins and applications can specify schemas this way.
 
-- `@auth(role: String)`: Restricts access to a table or field based on user roles.
+3. **Mark every table type with `@table`**. The type name becomes the table name by default. Use optional arguments to override behavior:
 
-## Configuring GraphQL Tooling
+   | Argument       | Type      | Default                       | Description                                                   |
+   | -------------- | --------- | ----------------------------- | ------------------------------------------------------------- |
+   | `table`        | `String`  | type name                     | Override the table name                                       |
+   | `database`     | `String`  | `"data"`                      | Database to place the table in                                |
+   | `expiration`   | `Int`     | —                             | Seconds until a record goes stale                             |
+   | `eviction`     | `Int`     | `0`                           | Additional seconds after `expiration` before physical removal |
+   | `scanInterval` | `Int`     | `(expiration + eviction) / 4` | Seconds between eviction scans                                |
+   | `replicate`    | `Boolean` | `true`                        | Enable replication of this table                              |
 
-To get the best IDE support (autocompletion, validation) and to help AI agents understand your schema context, you should create a `graphql.config.yml` file in your project root.
+4. **Designate a primary key on every table** using `@primaryKey`. Primary keys must be unique; duplicate-key inserts are rejected. If no key is provided on insert, Harper auto-generates one:
+   - `String` or `ID` → UUID string
+   - `Int`, `Long`, or `Any` → auto-incrementing integer
 
-This file tells GraphQL tools where to find Harper's built-in types and directives alongside your own schema files.
+   Prefer `Long` or `Any` for auto-generated numeric keys; `Int` is 32-bit and may be insufficient for large tables.
 
-### Creating `graphql.config.yml`
+5. **Index fields that need fast querying** with `@indexed`. This is required for filtering by that attribute in REST queries, SQL, or NoSQL operations. If the field value is an array, each element is individually indexed.
 
-Create a file named `graphql.config.yml` in your project root with the following content:
+   ```graphql
+   type Product @table {
+   	id: Long @primaryKey
+   	category: String @indexed
+   	price: Float @indexed
+   }
+   ```
 
-```yaml
-schema:
-  - 'node_modules/harper/schema.graphql'
-  - 'schema.graphql'
-  - 'schemas/*.graphql'
+6. **Expose a table as an external resource endpoint** with `@export`. This makes the table accessible via REST, MQTT, and other interfaces. The optional `name` parameter sets the URL path segment; without it, the type name is used.
+
+   ```graphql
+   type MyTable @table @export(name: "my-table") {
+   	id: Long @primaryKey
+   }
+   ```
+
+7. **Restrict extra properties** with `@sealed` when records must not include attributes beyond those declared. By default, Harper allows additional properties.
+
+   ```graphql
+   type StrictRecord @table @sealed {
+   	id: Long @primaryKey
+   	name: String
+   }
+   ```
+
+8. **Configure expiration, eviction, and scan behavior** together when building caching tables. These three arguments control the full record lifecycle:
+   - `expiration` — record becomes stale; next request triggers a source fetch
+   - `eviction` — additional time after `expiration` before physical removal
+   - `scanInterval` — how often Harper scans for records to evict; clock-aligned, not startup-aligned
+
+## Examples
+
+**Caching table with tuned expiration:**
+
+```graphql
+# Expire after 5 minutes, evict after 1 hour, scan every 10 minutes
+type WeatherCache @table(expiration: 300, eviction: 3300, scanInterval: 600) {
+	id: ID @primaryKey
+	temperature: Float
+}
 ```
 
-### Why this is important:
+**Table in a named database with expiration and an indexed field:**
 
-1. **Shared Directives**: It includes `@table`, `@primaryKey`, etc., so they aren't marked as "unknown directives".
-2. **Context for Agents**: When an agent reads your project, seeing this config helps it locate the core Harper definitions, leading to more accurate code generation.
-3. **Consistency**: The `npm create harper@latest` command includes this by default. Manually adding it to existing projects ensures they follow the same standards.
-
-## Example Project Structure
-
-A typical Harper project with proper schema tooling:
-
-```text
-my-harper-app/
-├── config.yaml
-├── graphql.config.yml
-├── package.json
-├── schema.graphql
-└── resources.js
+```graphql
+type Event @table(database: "analytics", expiration: 86400) {
+	id: Long @primaryKey
+	name: String @indexed
+}
 ```
+
+**Session cache with auto-expiry:**
+
+```graphql
+type Session @table(expiration: 3600) {
+	id: Long @primaryKey
+	userId: String
+}
+```
+
+**Table with audit timestamps:**
+
+```graphql
+type Order @table @export(name: "orders") {
+	id: Long @primaryKey
+	createdAt: Long @createdTime
+	updatedAt: Long @updatedTime
+	status: String @indexed
+}
+```
+
+**Overriding the table name and disabling replication:**
+
+```graphql
+type Product @table(table: "products") {
+	id: Long @primaryKey
+	name: String
+}
+
+type LocalRecord @table(replicate: false) {
+	id: Long @primaryKey
+	value: String
+}
+```
+
+## Notes
+
+- Use unique `database` names in plugins and applications to avoid table naming collisions, since all tables default to the `"data"` database.
+- Eviction removes non-indexed record data but does **not** remove a record from its secondary indexes. Indexes remain functional for evicted records; Harper fetches the full record from the source on demand when a query matches an evicted record.
+- `scanInterval` is clock-aligned to the server's local timezone. The server's startup time does not affect when eviction runs.
+- If replication is disabled on a table and later re-enabled, it will not catch up on writes made while replication was disabled.
+- Null values are indexed by `@indexed` fields, enabling queries such as `GET /Product/?category=null`.

--- a/harper-best-practices/rules/typescript-type-stripping.md
+++ b/harper-best-practices/rules/typescript-type-stripping.md
@@ -2,33 +2,63 @@
 name: typescript-type-stripping
 description: How to run TypeScript files directly in Harper without a build step.
 metadata:
-  mode: synthesized
+  mode: generate
+  sources:
+    - reference/v5/components/javascript-environment.md#TypeScript Support
+  sourceCommit: b7fbddadd42eb4487190b650a9abc4bcfeef5819
+  inputHash: 4e6bd8b610edd595
 ---
 
-# TypeScript Type Stripping
+# TypeScript Type Stripping in Harper
 
-Instructions for the agent to follow when using TypeScript in Harper.
+Instructions for the agent to run `.ts` files directly in Harper without a build step using Node.js's built-in type stripping.
 
 ## When to Use
 
-Use this skill when you want to write Harper Resources in TypeScript and have them execute directly in Node.js without an intermediate build or compilation step.
+Apply this rule when writing Harper resource files in TypeScript. Use it any time you need to reference `.ts` source files from `config.yaml` or import between local TypeScript modules in a Harper project.
 
 ## How It Works
 
-1. **Verify Node.js Version**: Ensure you are using Node.js v22.6.0 or higher.
-2. **Name Files with `.ts`**: Create your resource files in the `resources/` directory with a `.ts` extension.
-3. **Use TypeScript Syntax**: Write your resource classes using standard TypeScript (interfaces, types, etc.).
-   ```typescript
-   import { Resource } from 'harper';
-   export class MyResource extends Resource {
-   	async get(): Promise<{ message: string }> {
-   		return { message: 'Running TS directly!' };
-   	}
-   }
-   ```
-4. **Use Explicit Extensions in Imports**: When importing other local modules, include the `.ts` extension: `import { helper } from './helper.ts'`.
-5. **Configure `config.yaml`**: Ensure `jsResource` points to your `.ts` files:
+1. **Ensure Node.js version**: Require Node.js 22.6 or later. Type stripping is unavailable on earlier versions.
+
+2. **Point `jsResource` at `.ts` files**: The `jsResource` plugin loads both `.js` and `.ts` files. Set its `files` glob in `config.yaml` to target your `.ts` source files:
+
    ```yaml
    jsResource:
      files: 'resources/*.ts'
    ```
+
+3. **Use explicit `.ts` extensions in local imports**: Node's loader does not resolve `'./helper'` to `'./helper.ts'`, so always include the full extension:
+
+   ```typescript
+   import { helper } from './helper.ts';
+   ```
+
+4. **Stay within type-stripping limits**: Only type annotations and declarations are removed. Do not use enums with runtime values, namespaces with runtime semantics, or any other features that require code transformation beyond type stripping.
+
+## Examples
+
+A complete Harper resource written in TypeScript, using imports from the `harper` package:
+
+```typescript
+import { type RequestTargetOrId, Resource, tables } from 'harper';
+
+export class MyResource extends Resource {
+	async get(target?: RequestTargetOrId): Promise<{ message: string }> {
+		return { message: 'Hello from TS' };
+	}
+}
+```
+
+Paired `config.yaml` entry loading the file via `jsResource`:
+
+```yaml
+jsResource:
+  files: 'resources/*.ts'
+```
+
+## Notes
+
+- No build step or transpiler is required — Harper runs `.ts` files directly.
+- Type imports (e.g., `import { type RequestTargetOrId }`) from the `harper` package work as usual.
+- Unsupported TypeScript features include: enums with runtime values, namespaces with runtime semantics, and anything requiring code transformation beyond simple type stripping.


### PR DESCRIPTION
## What changed

### Rule migrations (3 rules → `mode: generate`)

| Rule | Sources |
|---|---|
| `creating-harper-apps` | `learn/getting-started/create-your-first-application.md` (primary) + `reference/v5/components/applications.md#Local Development` (supplemental) |
| `schema-design-tooling` | `reference/v5/database/schema.md` — Overview, Type Directives, Field Directives sections |
| `typescript-type-stripping` | `reference/v5/components/javascript-environment.md#TypeScript Support` |

All three rules were previously hand-authored (`mode: synthesized`). They are now generated from their declared docs sources and will stay in sync automatically via the existing `generate.yaml` dispatch/cron workflow. AGENTS.md and SKILL.md index are updated accordingly.

### Observability: generation-failure GitHub issue

Added a `Report generation failure` step to `.github/workflows/generate.yaml` that fires on any job failure. It creates a labelled GitHub issue (or appends a comment to an existing open issue for the same docs SHA) with a link to the failing run and a fix checklist pointing at Story 4 in the plan doc. Requires the new `issues: write` permission added to the workflow.

### Developer experience

- `.env.example` — documents `ANTHROPIC_API_KEY` as the required env var for `npm run generate`
- `CONTRIBUTING.MD` — new "Environment variables" section pointing contributors at `.env.example`

## Reviewer notes

- The three generated rule bodies are the main thing to read. They should cover the same ground as the old synthesized bodies but with tighter prose and explicit source provenance in frontmatter.
- `creating-harper-apps` was previously considered a candidate to stay `synthesized` (the `npm create harper@latest` CLI doesn't have its own reference page). Using the getting-started tutorial + `applications.md#Local Development` as sources produces a solid rule — reviewers can judge whether the generated output serves agents better than the old hand-authored version.
- The failure-issue step is `if: failure()` at the end of the job, so it fires on any preceding step failure including docs build, generation, and validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)