### PR TITLE
feat: add load-env rule to harper-best-practices manifest

### DIFF
--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -294,3 +294,19 @@ rules:
       - 'console.log'
       - 'logger'
       - 'withTag('
+
+  - rule: load-env
+    description: How to load environment variables from .env files into a Harper application using the loadEnv plugin.
+    category: ops
+    priority: 4
+    order: 6
+    mode: generate
+    sources:
+      - path: reference/v5/environment-variables/overview.md
+        role: primary
+    must_cover:
+      - 'loadEnv'
+      - 'files'
+      - 'process.env'
+      - 'override'
+      - 'config.yaml'


### PR DESCRIPTION
## Summary

- Adds a `load-env` rule entry to `harper-best-practices/rules.manifest.yaml`
- Category: `ops`, priority 4, order 6 (after `logging`)
- Mode: `generate`, sourced from `reference/v5/environment-variables/overview.md`
- `must_cover` assertions: `loadEnv`, `files`, `process.env`, `override`, `config.yaml`

## Motivation

Driven by a gap found in the existing skill coverage — no rule existed for the `loadEnv` plugin, which led to incorrect `loadEnv: true` usage. The companion docs fix is in [HarperFast/documentation#506](https://github.com/HarperFast/documentation/pull/506).

## Test plan

- [ ] `npm run validate` passes
- [ ] After merging the docs PR, run `npm run generate -- --rule load-env` and verify the generated rule body covers all `must_cover` terms

🤖 Generated with [Claude Code](https://claude.com/claude-code)