### PR TITLE
docs: conclude docs-driven lift, open comprehensive-rule-coverage cycle

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -2,7 +2,7 @@ name: Generate Rules from Docs
 
 # Regenerates docs-driven skill rules and opens a sync PR. Triggered when the
 # documentation repo deploys (repository_dispatch), on a weekly safety-net
-# cron, or manually. See docs/plans/docs-driven-skills.md (Phase 2).
+# cron, or manually. See docs/plans-archive/docs-driven-skills.md (Phase 2).
 #
 # Offline-first: the docs repo is checked out and built in-job; the generator
 # reads the local build output and never fetches docs over the network.
@@ -125,7 +125,7 @@ jobs:
 
           Opened automatically by \`.github/workflows/generate.yaml\`. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the full error.
 
-          **Common causes and fixes (Story 4 in docs/plans/docs-driven-skills.md):**
+          **Common causes and fixes (Story 4 in docs/plans-archive/docs-driven-skills.md):**
           - Source file renamed or moved — update \`sources[].path\` in \`rules.manifest.yaml\`.
           - Section heading renamed or removed — update \`sources[].section\`.
           - Must-cover assertion no longer in source — update \`must_cover\` or the section changed.
@@ -172,7 +172,7 @@ jobs:
               --title "docs: regenerate rules from documentation@${SHORT}" \
               --body "Automated regeneration of docs-driven skill rules from \`HarperFast/documentation@${SHORT}\`.
 
-          Produced by \`.github/workflows/generate.yaml\`. Review the diff as you would any rule change — the generator reads the docs build output and rewrites \`mode: generate\` / imports \`mode: direct\` rule bodies, then reassembles AGENTS.md. See docs/plans/docs-driven-skills.md.
+          Produced by \`.github/workflows/generate.yaml\`. Review the diff as you would any rule change — the generator reads the docs build output and rewrites \`mode: generate\` / imports \`mode: direct\` rule bodies, then reassembles AGENTS.md. See docs/plans-archive/docs-driven-skills.md.
 
           🤖 Generated with [Claude Code](https://claude.com/claude-code)"
           fi

--- a/docs/plans-archive/docs-driven-skills.md
+++ b/docs/plans-archive/docs-driven-skills.md
@@ -1,5 +1,7 @@
 # Docs-Driven Skill Generation
 
+> **Status: complete — archived.** The docs-driven generation pipeline shipped across Phases 0–4. The cross-repo `repository_dispatch` trigger from `HarperFast/documentation` is live and working: docs merges automatically open regeneration PRs against this repo. Of the 20 rules, 11 are `mode: generate` and 9 remain `synthesized`. The observability extras originally scoped into Phase 4 (stale-PR Slack notifier, weekly drift report) were intentionally deferred — see [Phase 4](#phase-4--awkward-rules--observability). The next development cycle — comprehensive v5 rule coverage and migrating the remaining synthesized rules — is tracked in [`docs/plans/comprehensive-rule-coverage.md`](../plans/comprehensive-rule-coverage.md). This document is retained as a record of the initial lift.
+
 ## Goal
 
 Eliminate drift between `@harperfast/skills` and `HarperFast/documentation`. Today rule bodies are maintained by hand — sometimes with agent assistance, but a human still has to notice a docs change, prompt the rewrite, and open a PR. As the docs evolve, skills silently fall behind. We're moving to a model where rule bodies are **generated from docs automatically** and humans only intervene to shape the _taxonomy_ — which rules exist, what docs feed them, and what each rule must assert.
@@ -312,11 +314,15 @@ Take on the rules that have multi-source bundles or no clean canonical doc, and 
 
 Rule candidates: `typescript-type-stripping`, `creating-harper-apps`, `schema-design-tooling`. Some will migrate with multi-source bundles; some will stay `synthesized` permanently if no canonical docs exist.
 
+**Shipped:** `typescript-type-stripping` and `schema-design-tooling` migrated to `mode: generate`. `creating-harper-apps` was intentionally left `synthesized` — its content (the `create-harper` CLI flow) has no clean canonical docs source today; see the [Learn-content question](../plans/comprehensive-rule-coverage.md) in the next-cycle plan.
+
 Observability work:
 
-- Stale-PR Slack notifier (auto-PRs open >7 days).
-- Generation-failure auto-issue (idempotent by docs SHA).
-- Weekly drift report (commits to docs main since last successful sync).
+- ✅ **Generation-failure auto-issue** (idempotent by docs SHA) — shipped in `generate.yaml`.
+- ⏸️ **Stale-PR Slack notifier** (auto-PRs open >7 days) — _deferred._
+- ⏸️ **Weekly drift report** (commits to docs main since last successful sync) — _deferred._
+
+> **Deferral note.** The Slack notifier and drift report were de-scoped from the initial lift. The failure auto-issue already covers the highest-value signal (a broken sync surfaces loudly as a GitHub issue), and the volume of auto-PRs is currently low enough that staleness and drift are visible by eye. These two notifiers are now **future follow-ups, to be picked up only when we deem them necessary** (e.g. if auto-PR volume grows or syncs start silently lagging). The blocking open question below (Slack channel + webhook) is parked along with them.
 
 ### Phase 5 — Steady state
 
@@ -334,7 +340,7 @@ Required sections:
 - **Common tasks.** "How do I add a new rule?" "How do I change which docs feed a rule?" "How do I add a new skill?" "An auto-PR looks wrong — what do I do?" — each with concrete commands.
 - **What's automated vs. what's manual.** Reproduce the guiding principle and a condensed version of the user stories above.
 
-The plan document you are reading lives at `docs/plans/docs-driven-skills.md`. It is a planning artifact, not steady-state documentation — once Phase 5 lands, this file can be archived. `.github/CONTRIBUTING.MD` is the long-lived companion.
+The plan document you are reading now lives at `docs/plans-archive/docs-driven-skills.md` (archived once the initial lift completed). It is a planning artifact, not steady-state documentation. `.github/CONTRIBUTING.MD` is the long-lived companion, and the next development cycle continues in [`docs/plans/comprehensive-rule-coverage.md`](../plans/comprehensive-rule-coverage.md).
 
 ## Validation Layer
 
@@ -403,4 +409,4 @@ Each question is annotated with the earliest phase it blocks; resolve before tha
 - **(Phase 1)** Confirm `reference_versioned_docs/version-v4/` is excluded from source resolution by default (handled via the plugin's `excludeRoutes` config).
 - **(Phase 2)** Anthropic API key provisioning for the skills repo's Actions runner — who owns it.
 - ~~**(Phase 2)** Confirm `SKILL.md` is "authored top + generated index at the bottom" — i.e., the rule list table is regenerated, the upper prose is not.~~ **Resolved (Phase 3).** Implemented: the "Rule Categories by Priority" table and "Quick Reference" section are generated inside sentinel comments; all other prose is hand-authored. See Generation Lifecycle step 3b and Validation Layer for details.
-- **(Phase 4)** Slack channel + webhook for stale-PR and failure notifications.
+- ~~**(Phase 4)** Slack channel + webhook for stale-PR and failure notifications.~~ **Parked.** The stale-PR and drift notifiers were deferred (see [Phase 4](#phase-4--awkward-rules--observability)); this question is revisited only if/when those follow-ups are picked up.

--- a/docs/plans/comprehensive-rule-coverage.md
+++ b/docs/plans/comprehensive-rule-coverage.md
@@ -1,0 +1,103 @@
+# Comprehensive v5 Rule Coverage
+
+> **Status: meta plan / open.** This document frames the next development cycle for `@harperfast/skills`. It records goals, an honest map of where the ruleset stands today, and the open questions that must be answered before committing to phased execution. It deliberately does **not** answer those questions yet — it scopes the cycle and surfaces the decisions. Phased detail is added once the open questions below are resolved.
+
+## Context
+
+The [docs-driven generation pipeline](../plans-archive/docs-driven-skills.md) is built and live. Docs merges in `HarperFast/documentation` fire a `repository_dispatch` at this repo, which regenerates `mode: generate` rule bodies from the docs build output and opens a PR. That was the _initial lift_: prove the machinery end-to-end and migrate the rules that mapped cleanly.
+
+This cycle is about **content, not machinery**. The pipeline works; the question now is whether the ruleset it maintains actually covers Harper v5 well, and what it would take to get there.
+
+## Guiding Principle (carried forward)
+
+> **Humans own the rule taxonomy. Automation owns keeping rule bodies in sync with their declared sources.**
+
+The same principle applies. This cycle expands the taxonomy (which rules exist, what they map to) — all human-owned PRs — while leaning on the existing automation to keep bodies fresh.
+
+## Primary Objective
+
+**Build a comprehensive ruleset covering all of Harper v5 documentation.** "Comprehensive" means an agent working in a Harper v5 codebase can find a rule for any documented capability it might reasonably need, and that rule is sourced from (and stays in sync with) the canonical docs.
+
+## Current Rule Map
+
+21 rules across 4 categories. 11 are `mode: generate` (docs-driven, auto-synced); 10 are `mode: synthesized` (hand-authored, untracked against docs); **0 are `mode: direct`** — the verbatim-import mode is built and validated but has never been used by a real rule.
+
+| Category | Rule                                    | Mode        | Notes                                                                                   |
+| -------- | --------------------------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| schema   | `adding-tables-with-schemas`            | synthesized | Candidate to migrate — schema docs exist                                                |
+| schema   | `schema-design-tooling`                 | generate    | ✅ migrated (Phase 4)                                                                   |
+| schema   | `defining-relationships`                | synthesized | Candidate to migrate                                                                    |
+| schema   | `vector-indexing`                       | generate    | ✅ migrated (Phase 2)                                                                   |
+| schema   | `using-blob-datatype`                   | synthesized | Candidate to migrate                                                                    |
+| schema   | `handling-binary-data`                  | synthesized | Candidate to migrate                                                                    |
+| api      | `automatic-apis`                        | generate    | ✅ migrated (Phase 3)                                                                   |
+| api      | `querying-rest-apis`                    | generate    | ✅ migrated (Phase 3)                                                                   |
+| api      | `real-time-apps`                        | generate    | ✅ migrated (Phase 3)                                                                   |
+| api      | `checking-authentication`               | generate    | ✅ migrated (Phase 3)                                                                   |
+| logic    | `custom-resources`                      | synthesized | Candidate to migrate                                                                    |
+| logic    | `extending-tables`                      | synthesized | Candidate to migrate                                                                    |
+| logic    | `programmatic-table-requests`           | synthesized | Candidate to migrate                                                                    |
+| logic    | `typescript-type-stripping`             | generate    | ✅ migrated (Phase 4)                                                                   |
+| logic    | `caching`                               | generate    | ✅ migrated (Phase 3)                                                                   |
+| ops      | `deploying-to-harper-fabric`            | generate    | ✅ migrated (Phase 3)                                                                   |
+| ops      | `creating-a-fabric-account-and-cluster` | synthesized | Candidate to migrate                                                                    |
+| ops      | `creating-harper-apps`                  | synthesized | **Intentionally synthesized** — `create-harper` CLI lacks a clean canonical docs source |
+| ops      | `serving-web-content`                   | synthesized | Candidate to migrate                                                                    |
+| ops      | `logging`                               | generate    | ✅ migrated (Phase 3)                                                                   |
+| ops      | `load-env`                              | generate    | ✅ migrated (Phase 3)                                                                   |
+
+So the migration backlog is **9 synthesized rules that are candidates to move to `generate` or `direct`**, plus **1 (`creating-harper-apps`) intentionally held back** pending docs. (Note: an earlier informal count said "11 generate / 9 synthesized" — the accurate split is 11 / 10; `load-env` was the rule not counted.)
+
+## Goals & Open Questions
+
+These are the questions this cycle must answer. They are recorded here as design considerations, not yet resolved. Each will get a worked answer (and likely its own phase) as the plan matures.
+
+### 1. How do we ensure we cover "everything"?
+
+The objective is comprehensive coverage, which means we need a definition of "covered" that is **mechanically checkable**, not aspirational. Candidate approach:
+
+- Treat the set of Harper v5 reference pages (the `reference/v5/**` routes in the docs build output) as the coverage universe.
+- Assert that every reference page is referenced by at least one rule's `sources[]`. This becomes a new validation check — a _coverage report_ that lists reference pages with no owning rule.
+- Decide what to do about partial coverage: a rule may source one `section` of a page while other sections go uncovered. Section-level coverage tracking may be needed, not just page-level.
+
+Open: is page-level coverage the right granularity, or do we need section-level? Should `learn/` and `fabric/` count toward the coverage universe, or only `reference/v5/`? (See Question 5 on Learn content.)
+
+### 2. What documentation is _not_ covered by rules today?
+
+Before planning new rules, produce a **gap analysis**: enumerate the docs build output, subtract everything currently referenced by a `sources[]` entry in the manifest, and list the remainder. That list — the uncovered docs — is the raw backlog of candidate new rules. This is a prerequisite deliverable for the whole cycle; we can't scope "comprehensive" without knowing the denominator.
+
+### 3. Migrate the synthesized rules
+
+Nine synthesized rules are candidates to move to `generate` or `direct`. For each, the work is: find the canonical docs source, decide the mode (`generate` if the source benefits from rephrasing/multi-source bundling; `direct` if it's already concise and verbatim auditability is preferable), populate `sources[]` + `must_cover`, regenerate, and open a PR. This is also the natural opportunity to **put the `direct` mode into real use for the first time** — at least one of these rules is likely a better fit for verbatim import than LLM rewrite.
+
+`creating-harper-apps` stays synthesized until the `create-harper` CLI has canonical docs (tied to Question 5).
+
+### 4. How should Learn content be incorporated into rules?
+
+The `creating-harper-apps` rule surfaced a real tension: it should _not_ have referenced the "Getting Started" Learn guide, because that guide is a **manual, narrative walkthrough** while the rule describes the **automated `create-harper` flow**. The Learn guide and the rule are answering different questions, and stapling them together produced a worse rule.
+
+The general lesson: **`learn/` content is narrative/tutorial, `reference/` content is canonical/atomic.** Rules want atomic, action-oriented source material. Learn guides may be the wrong shape to source rules from directly — or may need a different template/treatment than reference pages.
+
+Open questions:
+
+- Should rules source from `learn/` at all, or only from `reference/v5/`? If Learn content is sourced, does `mode: generate` need Learn-specific prompt guidance to extract the actionable core from narrative prose?
+- This points at a **docs-readiness problem**: where reference docs are thin or missing (e.g. `create-harper`), no amount of skill tooling produces a good rule. **Should skill development lightly pause on rules whose canonical docs aren't yet ironed out**, and instead feed a list of "docs gaps blocking good rules" back to the docs team?
+- How does docs-readiness factor into sequencing? Likely: do the gap analysis (Q2) first, split the uncovered backlog into "docs are ready, write the rule" vs. "docs need work first, file a docs issue," and only schedule the former into this cycle.
+
+## Proposed Shape (provisional)
+
+Not committed — sketched so the cycle has a spine once the questions above are answered.
+
+- **Phase A — Coverage instrumentation.** Build the coverage report (Q1) and the gap analysis (Q2) as a script/validation check. Output: a concrete, regenerable list of covered vs. uncovered docs.
+- **Phase B — Synthesized migration sweep.** Work through the 9 candidate synthesized rules (Q3), one small PR each, including the first real `direct`-mode rule. Hold `creating-harper-apps`.
+- **Phase C — Fill the gaps.** Using Phase A's uncovered list, author new rules for documented-but-unruled capabilities — but only where docs are ready (Q4/Q5). File docs issues for the rest.
+- **Phase D — Coverage gate.** Once coverage is high, consider promoting the coverage report from informational to a CI gate (new reference pages must be claimed by a rule, or explicitly waived).
+
+## Out of Scope (carried over as future follow-ups)
+
+The observability extras deferred from the prior cycle remain deferred and are **not** part of this cycle unless a need emerges:
+
+- Stale-PR Slack notifier (auto-PRs open >7 days).
+- Weekly drift report (commits to docs main since last successful sync).
+
+The generation-failure auto-issue already shipped and covers the highest-value failure signal. See the [archived plan's Phase 4](../plans-archive/docs-driven-skills.md#phase-4--awkward-rules--observability) for context.

--- a/harper-best-practices/rules.manifest.yaml
+++ b/harper-best-practices/rules.manifest.yaml
@@ -2,7 +2,7 @@
 #
 # Declarative source of truth for rule taxonomy, sources, and generation mode.
 # Owned by humans; the generator reads this file and writes derived artifacts
-# (rule bodies, AGENTS.md). See docs/plans/docs-driven-skills.md for the
+# (rule bodies, AGENTS.md). See docs/plans-archive/docs-driven-skills.md for the
 # full schema definition and Manifest ↔ frontmatter reconciliation semantics.
 #
 # Phase 2 flipped vector-indexing to mode: generate.

--- a/scripts/generation/lib/manifest.mjs
+++ b/scripts/generation/lib/manifest.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import yaml from 'js-yaml';
 
 // Each entry describes a skill directory. Add new skills here as they are
-// introduced (Story 5 in docs/plans/docs-driven-skills.md describes the
+// introduced (Story 5 in docs/plans-archive/docs-driven-skills.md describes the
 // multi-skill case).
 export const SKILLS = [
 	{

--- a/scripts/generation/lib/sources.mjs
+++ b/scripts/generation/lib/sources.mjs
@@ -2,7 +2,7 @@
 // (to feed the LLM / produce direct bodies) and the validator (source-exists
 // and byte-identical checks). The docs build dir is the `build/` tree produced
 // by @signalwire/docusaurus-plugin-llms-txt — see Phase 1 in
-// docs/plans/docs-driven-skills.md. No network access: everything reads from
+// docs/plans-archive/docs-driven-skills.md. No network access: everything reads from
 // the local checked-out-and-built docs tree.
 
 import fs from 'node:fs/promises';

--- a/scripts/generation/validate-generated.mjs
+++ b/scripts/generation/validate-generated.mjs
@@ -1,7 +1,7 @@
 // Validator for the docs-driven skill generation system.
 //
 // Implements Layers 2–4 of the validation taxonomy in
-// docs/plans/docs-driven-skills.md:
+// docs/plans-archive/docs-driven-skills.md:
 //
 //   - Layer 2 (manifest lint): the manifest conforms to the schema.
 //   - Layer 3 (manifest ↔ frontmatter reconciliation): each rule file's


### PR DESCRIPTION
## Summary

The docs-driven generation pipeline (Phases 0–4 of the now-archived plan) is **complete and live** — the cross-repo `repository_dispatch` trigger from `HarperFast/documentation` regenerates `mode: generate` rule bodies on docs merges and opens PRs. This PR concludes that initial lift and transitions into the next development cycle.

### What changed

1. **Amended the docs-driven-skills plan** to reflect reality:
   - Marked the plan complete with a status banner.
   - Recorded that the two Phase 4 observability extras — the **stale-PR Slack notifier** and **weekly drift report** — are **intentionally deferred to future follow-ups**. The generation-failure auto-issue already shipped and covers the highest-value signal; current auto-PR volume is low enough that staleness/drift are visible by eye. The blocking Slack-webhook open question is parked alongside them.

2. **Archived the plan** by moving it to `docs/plans-archive/docs-driven-skills.md` (rename preserves history) and updated the now-stale path references across `rules.manifest.yaml`, the generation scripts, and `generate.yaml`.

3. **Opened a new meta plan** at `docs/plans/comprehensive-rule-coverage.md` for the next cycle. It is intentionally a framing document — it scopes the work and surfaces decisions without answering them yet:
   - **Primary objective:** a comprehensive ruleset covering all of Harper v5 documentation.
   - **Current rule map:** 21 rules — **11 `generate` / 10 `synthesized` / 0 `direct`**. (Corrects the informal "11/9" count; `load-env` was the uncounted rule.)
   - **Open questions** carried in verbatim from the cycle kickoff: how to mechanically measure "covered everything", what docs are uncovered today (gap analysis), migrating the 9 candidate synthesized rules (and putting `direct` mode to real use), and how Learn content + docs readiness should factor in — including whether to lightly pause rule work where canonical docs aren't yet ironed out (the `creating-harper-apps` / Getting Started lesson).

### Validation

`npm run validate` passes (format, build, skill validation, manifest/frontmatter reconciliation). Changes are documentation + comment-string path updates only; no rule bodies or generation behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)