### PR TITLE
feat: rule baseline freshness guard + provenance-rich sync PRs

### DIFF
--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -42,6 +42,7 @@ Every file and directory at a glance — nothing is skipped because "it's obviou
 │   ├── validate-skills.mjs      # Layer 1 validator: basic SKILL.md / rule schema
 │   └── generation/
 │       ├── generate-rules.mjs   # Rule generator (entry point for npm run generate)
+│       ├── sync-report.mjs      # Baseline-freshness report + sync PR body composer
 │       ├── validate-generated.mjs  # Layers 2–4 validator: manifest lint,
 │       │                           # frontmatter reconciliation, body checks
 │       ├── lib/
@@ -146,7 +147,9 @@ When docs change (or on a weekly safety-net cron), `.github/workflows/generate.y
 
 1. **Checks out `HarperFast/documentation`** at the triggering SHA and runs `npm ci && npm run build` in it. This produces per-route flat-markdown files under `documentation/build/` via the `@signalwire/docusaurus-plugin-llms-txt` Docusaurus plugin.
 
-2. **Reads `rules.manifest.yaml`** and iterates over every non-synthesized rule.
+2. **Captures pre-sync provenance** — `sync-report.mjs` snapshots each rule's recorded baseline and which rules are stale, before generation overwrites the frontmatter. The sync PR body is composed from this snapshot.
+
+3. **Reads `rules.manifest.yaml`** and iterates over every non-synthesized rule.
 
 3. **Resolves sources** — for each `sources[].path`, reads the corresponding file from `documentation/build/`. If `sources[].section` is set, slices out that heading's content subtree. Concatenates sources in manifest order.
 
@@ -189,15 +192,23 @@ This flow is **offline-first**: no network calls to `docs.harperdb.io`. Everythi
        - 'key term that must appear in the generated body'
    ```
 
-2. Run the generator locally (you need the docs repo checked out and built):
+2. Run the generator locally. You need the docs repo checked out **and built at `main` HEAD** — see [Keeping rule baselines fresh](#keeping-rule-baselines-fresh) for why this matters:
 
    ```bash
+   git -C ../documentation switch main && git -C ../documentation pull
+   npm --prefix ../documentation ci && npm --prefix ../documentation run build
    npm run generate -- --docs-path ../documentation --rule my-new-rule
    ```
 
    Omit `--rule` to regenerate all changed rules. Use `--force` to regenerate even when the input hash is unchanged.
 
 3. Review the generated `harper-best-practices/rules/my-new-rule.md`, then open a PR with a `feat:` commit.
+
+   Before opening, confirm the recorded baseline matches current docs main (catches a rule that was generated against a stale docs checkout):
+
+   ```bash
+   npm run sync:report -- --docs-path ../documentation --strict
+   ```
 
 For `mode: synthesized` (no docs source), omit `sources[]` and `must_cover`, write the rule body by hand, and open the PR.
 
@@ -239,6 +250,25 @@ Check what changed in the docs at the linked commit SHA. Common cases:
 
 Close the auto-PR without merging, fix the manifest on a new branch, and open a corrective PR against `main`. The next auto-sync will be a no-op once your fix merges.
 
+### Keeping rule baselines fresh
+
+Every `generate` / `direct` rule records the docs commit and content hash it was last produced from (`metadata.sourceCommit` / `metadata.inputHash`). That recorded baseline reflects **whatever local docs checkout you had** when you ran `npm run generate`.
+
+If your docs checkout lags `main`, the rule is "born stale": its body reflects old docs, and the recorded hash points at an old commit. Nothing is lost — the next auto-sync regenerates it against current docs — but the resulting sync PR looks confusing, because a docs commit about feature X appears to regenerate an unrelated rule (the rule's *real* source changed in an earlier, never-synced commit).
+
+To avoid this:
+
+- **Build docs at `main` HEAD before generating** (see the commands in [How do I add a new rule?](#how-do-i-add-a-new-rule)).
+- **Run the freshness check before opening a rule PR:**
+
+  ```bash
+  npm run sync:report -- --docs-path ../documentation --strict
+  ```
+
+  It compares every rule's recorded hash against the current docs build and exits non-zero (under `--strict`) if any rule is stale. A clean run means your baselines match the docs you built against. Drop `--strict` for an informational report.
+
+The auto-sync workflow runs the same report before regenerating and uses it to explain each sync PR — listing which rules changed, the docs commit each was last synced from, and the full docs commit range since that baseline.
+
 ---
 
 ## What's automated vs. what's manual
@@ -253,7 +283,8 @@ Close the auto-PR without merging, fix the manifest on a new branch, and open a 
 | Write `synthesized` rule bodies | Human |
 | Regenerate `generate` / `direct` bodies when docs change | Automated (dispatch + cron) |
 | Reassemble AGENTS.md and SKILL.md index | Automated (every generation run) |
-| Open sync PRs | Automated (`generate.yaml`) |
+| Open sync PRs (with per-rule change provenance) | Automated (`generate.yaml` + `sync-report.mjs`) |
+| Keep recorded baselines current with docs main | Human (build docs at HEAD; `npm run sync:report --strict`) |
 | Open failure issues when generation breaks | Automated (`generate.yaml`) |
 | Review and merge sync PRs | Human |
 | Publish new npm versions | Automated (semantic-release on merge to main) |
@@ -269,6 +300,7 @@ When a docs structural change breaks automation (renamed file, renamed heading),
 - **Build**: `npm run build` — compiles `dist/`.
 - **Validate**: `npm run validate` — runs `format:check` + `build` + both validators. Run this before pushing.
 - **Validate with docs**: add `&& node scripts/generation/validate-generated.mjs --docs-path ../documentation` for the full suite including source-exists and byte-identical checks.
+- **Freshness report**: `npm run sync:report -- --docs-path ../documentation` — shows which rules are stale vs. the current docs build. Add `--strict` to fail on staleness (use before opening a rule PR).
 
 The pipeline is ordered so `format:check` runs first. CI fails loudly on formatting drift rather than silently auto-fixing it.
 

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -64,7 +64,9 @@ jobs:
           ref: ${{ steps.docsref.outputs.ref }}
           path: documentation
           # documentation is a public repo, so the default job token reads it.
-          fetch-depth: 1
+          # Full history (fetch-depth: 0) so the sync PR body can resolve the
+          # docs commit range since each rule's recorded baseline.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -80,6 +82,14 @@ jobs:
       - name: Install skills dependencies
         working-directory: skills
         run: npm ci
+
+      - name: Capture pre-sync provenance
+        working-directory: skills
+        # Snapshot each rule's recorded baseline (sourceCommit/inputHash) and
+        # which rules are stale, BEFORE generation overwrites the frontmatter.
+        # The PR step reads this snapshot to explain why each rule changed.
+        # Non-strict: this never blocks the sync — the generator is the gate.
+        run: npm run sync:report -- --docs-path ../documentation --out ../sync-provenance.json
 
       - name: Generate rules
         working-directory: skills
@@ -164,15 +174,22 @@ jobs:
           # commit in place so the open sync PR always reflects the latest docs.
           git push --force origin "$BRANCH"
 
+          # Compose a provenance-rich body from the pre-sync snapshot: which
+          # rules changed, the docs commit each was last synced from, and the
+          # full docs commit range since the oldest such baseline.
+          BODY="$(npm run --silent sync:report -- \
+            --docs-path ../documentation \
+            --format pr-body \
+            --from ../sync-provenance.json)"
+
           STATE=$(gh pr view "$BRANCH" --json state --jq .state 2>/dev/null || echo "")
           if [ "$STATE" = "OPEN" ]; then
             echo "Existing sync PR updated."
+            gh pr edit "$BRANCH" \
+              --title "docs: regenerate rules from documentation@${SHORT}" \
+              --body "$BODY"
           else
             gh pr create --base main --head "$BRANCH" \
               --title "docs: regenerate rules from documentation@${SHORT}" \
-              --body "Automated regeneration of docs-driven skill rules from \`HarperFast/documentation@${SHORT}\`.
-
-          Produced by \`.github/workflows/generate.yaml\`. Review the diff as you would any rule change — the generator reads the docs build output and rewrites \`mode: generate\` / imports \`mode: direct\` rule bodies, then reassembles AGENTS.md. See docs/plans/docs-driven-skills.md.
-
-          🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+              --body "$BODY"
           fi

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"format": "oxfmt",
 		"format:check": "oxfmt --check",
 		"generate": "node scripts/generation/generate-rules.mjs",
+		"sync:report": "node scripts/generation/sync-report.mjs",
 		"validate": "npm run format:check && npm run build && node scripts/validate-skills.mjs && node scripts/generation/validate-generated.mjs"
 	},
 	"devDependencies": {

--- a/scripts/generation/sync-report.mjs
+++ b/scripts/generation/sync-report.mjs
@@ -1,0 +1,279 @@
+// Sync provenance + freshness reporter for the docs-driven rule pipeline.
+//
+// Every `generate` / `direct` rule records the docs commit and source-content
+// hash it was last produced from (`metadata.sourceCommit` / `metadata.inputHash`
+// in the rule's frontmatter). That recorded baseline reflects whatever local
+// docs checkout the author had when they ran `npm run generate` — which can lag
+// docs `main`. When it lags, the next auto-sync regenerates the rule against
+// current docs and produces what looks like an unrelated change (e.g. a docs
+// commit about feature X regenerates the loadEnv rule, because the loadEnv
+// source actually changed in an *earlier* unsynced commit). See
+// docs/plans/docs-driven-skills.md.
+//
+// This script makes that drift legible. It compares each rule's recorded
+// inputHash against the hash of its current resolved source content in a docs
+// build, and reports which rules are stale (i.e. will regenerate).
+//
+// Two jobs, selected by --format:
+//
+//   --format text|json   Freshness report. Used locally (with --strict, as an
+//                         author-time guard before opening a manual rule PR)
+//                         and in CI (non-strict, to capture provenance before
+//                         regeneration runs). Pass --out <file> to also write
+//                         the JSON snapshot for a later pr-body pass to consume.
+//
+//   --format pr-body     Compose the sync PR body from a pre-regeneration JSON
+//                         snapshot (--from <file>). Lists the rules that changed,
+//                         the docs commit each was last synced from, and the full
+//                         docs commit range since the oldest such baseline — so a
+//                         reviewer sees *why* each rule regenerated, not just the
+//                         head SHA. Needs git history in the docs checkout
+//                         (the workflow checks out documentation at fetch-depth: 0).
+//
+// Offline-first: hashing reads only the local docs build; pr-body reads only the
+// local docs git history. No network calls.
+//
+// Usage:
+//   node scripts/generation/sync-report.mjs --docs-path ../documentation
+//   node scripts/generation/sync-report.mjs --docs-path ../documentation --strict
+//   node scripts/generation/sync-report.mjs --docs-path ../documentation --out ../provenance.json
+//   node scripts/generation/sync-report.mjs --docs-path ../documentation --format pr-body --from ../provenance.json
+//
+// Exit codes (report modes): 1 only when --strict and there is at least one
+// stale rule or resolution error; 0 otherwise. pr-body always exits 0.
+
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+import matter from 'gray-matter';
+
+import { loadManifest, SKILLS } from './lib/manifest.mjs';
+import { computeInputHash, resolveSources } from './lib/sources.mjs';
+
+const PLAN_PATH = 'docs/plans/docs-driven-skills.md';
+
+function parseArgs(argv) {
+	const args = {
+		docsPath: process.env.DOCS_PATH || '../documentation',
+		format: 'text',
+		strict: false,
+		out: null,
+		from: null,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--docs-path') args.docsPath = argv[++i];
+		else if (a === '--format') args.format = argv[++i];
+		else if (a === '--strict') args.strict = true;
+		else if (a === '--out') args.out = argv[++i];
+		else if (a === '--from') args.from = argv[++i];
+		else throw new Error(`Unknown argument: ${a}`);
+	}
+	if (!['text', 'json', 'pr-body'].includes(args.format)) {
+		throw new Error(`--format must be one of text / json / pr-body (got ${args.format})`);
+	}
+	return args;
+}
+
+const short = (sha) => (sha && sha !== 'unknown' ? sha.slice(0, 7) : 'unknown');
+
+// Compute the freshness of every generate/direct rule against a docs build.
+async function computeFreshness(docsBuildDir) {
+	const results = [];
+	for (const skill of SKILLS) {
+		const manifest = await loadManifest(skill);
+		const rulesDir = path.join(process.cwd(), skill.dir, skill.rulesDir);
+		for (const entry of manifest.rules) {
+			if (entry.mode !== 'generate' && entry.mode !== 'direct') continue;
+
+			const row = {
+				skill: skill.dir,
+				rule: entry.rule,
+				mode: entry.mode,
+				recordedCommit: null,
+				recordedHash: null,
+				currentHash: null,
+				stale: false,
+				error: null,
+			};
+
+			try {
+				const raw = await fs.readFile(path.join(rulesDir, `${entry.rule}.md`), 'utf-8');
+				const meta = matter(raw).data?.metadata ?? {};
+				row.recordedCommit = meta.sourceCommit ?? null;
+				row.recordedHash = meta.inputHash ?? null;
+			} catch (err) {
+				row.error = `cannot read rule file: ${err.message}`;
+				results.push(row);
+				continue;
+			}
+
+			try {
+				const resolved = await resolveSources(docsBuildDir, entry.sources);
+				row.currentHash = computeInputHash(resolved);
+				row.stale = row.recordedHash !== row.currentHash;
+			} catch (err) {
+				row.error = `cannot resolve sources: ${err.message}`;
+			}
+			results.push(row);
+		}
+	}
+	return results;
+}
+
+function printText(results) {
+	const stale = results.filter((r) => r.stale);
+	const errored = results.filter((r) => r.error);
+	const fresh = results.length - stale.length - errored.length;
+
+	console.log('Rule baseline freshness (recorded vs. current docs build):\n');
+	for (const r of results) {
+		const status = r.error ? '⚠ error ' : r.stale ? '✗ stale ' : '✓ fresh ';
+		const detail = r.error
+			? r.error
+			: r.stale
+				? `recorded ${short(r.recordedCommit)} (${r.recordedHash}) → current ${r.currentHash}`
+				: `current with ${short(r.recordedCommit)}`;
+		console.log(`  ${status} ${r.rule.padEnd(32)} ${detail}`);
+	}
+	console.log(`\n${fresh} fresh, ${stale.length} stale, ${errored.length} error(s).`);
+	if (stale.length > 0) {
+		console.log(
+			'\nStale rules will be regenerated on the next sync. If a rule is stale\n' +
+				'immediately after you authored it, your local docs checkout likely lags\n' +
+				`docs main — pull + rebuild docs at main HEAD and regenerate. See ${PLAN_PATH}.`,
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pr-body: compose the sync PR description from a pre-regen snapshot.
+// ---------------------------------------------------------------------------
+
+function gitDocs(docsRepoPath, args) {
+	return execFileSync('git', ['-C', docsRepoPath, ...args], { encoding: 'utf-8' }).trim();
+}
+
+// Oldest (by commit time) of the given commits that exist in docs history.
+function oldestCommit(docsRepoPath, commits) {
+	let oldest = null;
+	for (const sha of commits) {
+		let ts;
+		try {
+			ts = Number(gitDocs(docsRepoPath, ['show', '-s', '--format=%ct', sha]));
+		} catch {
+			continue; // not in history (shallow clone / rebased) — skip
+		}
+		if (oldest === null || ts < oldest.ts) oldest = { sha, ts };
+	}
+	return oldest?.sha ?? null;
+}
+
+function composePrBody(docsRepoPath, snapshot) {
+	const headSha = gitDocs(docsRepoPath, ['rev-parse', 'HEAD']);
+	const headShort = short(headSha);
+	const changed = snapshot.filter((r) => r.stale);
+
+	const lines = [
+		`Automated regeneration of docs-driven skill rules, now synced to ` +
+			`\`HarperFast/documentation@${headShort}\`.`,
+		'',
+	];
+
+	if (changed.length === 0) {
+		// Force-run or AGENTS.md-only change with no stale rules.
+		lines.push('No rule sources changed since the last sync (derived artifacts refreshed).');
+	} else {
+		lines.push('### Why these rules changed', '');
+		lines.push(
+			'Each rule regenerated because its source content differs from the docs ' +
+				'commit it was last synced from. The trigger commit is **not** ' +
+				'necessarily what changed a given rule — drift accumulates across every ' +
+				'docs commit since the rule’s recorded baseline (below).',
+			'',
+		);
+		for (const r of changed) {
+			lines.push(`- \`${r.rule}\` — last synced from docs@${short(r.recordedCommit)}`);
+		}
+		lines.push('');
+
+		const baselines = [...new Set(changed.map((r) => r.recordedCommit).filter(Boolean))];
+		const start = oldestCommit(docsRepoPath, baselines);
+		if (start) {
+			let log = '';
+			try {
+				log = gitDocs(docsRepoPath, [
+					'log',
+					'--no-merges',
+					'--format=%h%x09%s',
+					`${start}..${headSha}`,
+				]);
+			} catch {
+				log = '';
+			}
+			lines.push(`### Docs commits since baseline (\`${short(start)}..${headShort}\`)`, '');
+			if (log) {
+				lines.push('```');
+				lines.push(log);
+				lines.push('```');
+			} else {
+				lines.push('_(no intervening commits resolved — docs history may be shallow)_');
+			}
+			lines.push('');
+		}
+	}
+
+	lines.push(
+		`Produced by \`.github/workflows/generate.yaml\`. Review the diff as you ` +
+			`would any rule change — the generator reads the docs build output and ` +
+			`rewrites \`mode: generate\` / imports \`mode: direct\` rule bodies, then ` +
+			`reassembles AGENTS.md. See ${PLAN_PATH}.`,
+		'',
+		'🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+	);
+	return lines.join('\n');
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const docsRepoPath = path.resolve(args.docsPath);
+	const docsBuildDir = path.join(docsRepoPath, 'build');
+
+	if (args.format === 'pr-body') {
+		if (!args.from) throw new Error('--format pr-body requires --from <snapshot.json>');
+		const snapshot = JSON.parse(await fs.readFile(args.from, 'utf-8'));
+		process.stdout.write(composePrBody(docsRepoPath, snapshot) + '\n');
+		return;
+	}
+
+	if (!fsSync.existsSync(docsBuildDir)) {
+		console.error(
+			`--docs-path given but ${docsBuildDir} does not exist. ` +
+				'Run `npm ci && npm run build` in the docs checkout first.',
+		);
+		process.exit(args.strict ? 1 : 0);
+	}
+
+	const results = await computeFreshness(docsBuildDir);
+
+	if (args.out) {
+		await fs.writeFile(args.out, JSON.stringify(results, null, 2), 'utf-8');
+	}
+
+	if (args.format === 'json') {
+		process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+	} else {
+		printText(results);
+	}
+
+	const anyStale = results.some((r) => r.stale);
+	const anyError = results.some((r) => r.error);
+	process.exit(args.strict && (anyStale || anyError) ? 1 : 0);
+}
+
+main().catch((err) => {
+	console.error('sync-report crashed:', err);
+	process.exit(2);
+});


### PR DESCRIPTION
## Background

This fixes the class of confusion surfaced by **PR #50**, where a docs commit about `describe_database` appeared to regenerate the unrelated `load-env` rule.

Root cause (not a hash bug): every `generate`/`direct` rule records the docs commit + content hash it was last produced from (`metadata.sourceCommit` / `metadata.inputHash`). That baseline reflects **whatever local docs checkout the author built against**, which can lag docs `main`. When it lags, the rule is "born stale" — its body reflects old docs, and the next auto-sync correctly regenerates it against current docs. The regen is legitimate (no lost updates), but the sync PR is confusing because the triggering commit isn't what actually changed the rule; an *earlier, unsynced* docs commit was (for `load-env`, that was #506 "clarify loadEnv files option is required").

## The three fixes (all opted into)

### 1. Process — `CONTRIBUTING.MD`
- "How do I add a new rule?" now shows pulling + building docs at `main` HEAD before generating.
- New **"Keeping rule baselines fresh"** section explains born-stale rules and the guard command.

### 2. Guard — `scripts/generation/sync-report.mjs` (`npm run sync:report`)
Compares each rule's recorded `inputHash` against the hash of its current resolved source in a docs build, and reports which rules are stale.

```bash
npm run sync:report -- --docs-path ../documentation --strict
```

`--strict` exits non-zero if any rule is stale — an **author-time** check (run against freshly-built docs main before opening a rule PR) that catches born-stale rules instead of letting them surface on a later, unrelated dispatch.

### 3. Provenance — `.github/workflows/generate.yaml`
- New **Capture pre-sync provenance** step snapshots each rule's recorded baseline + staleness *before* generation overwrites the frontmatter (non-strict; never blocks the sync — the generator remains the gate).
- The sync PR body is now composed from that snapshot: it lists **which rules changed, the docs commit each was last synced from, and the full docs commit range since the oldest baseline**. So PR #50 would have read "`load-env` — last synced from docs@b7fbddad" with #506 right there in the commit range, instead of just the head SHA.
- Docs checkout deepened to `fetch-depth: 0` so the commit range resolves.
- The rolling `auto/docs-sync` PR now refreshes its body on each update (`gh pr edit`), not just on first creation.

## Testing
- `npm run validate` passes (format, build, both validators).
- Freshness report verified against the local docs checkout (all rules fresh at the matching baseline).
- `--strict` exit codes verified: 0 when fresh, 1 when stale/missing-build; 0 in non-strict.
- `pr-body` verified against a synthetic 3-commit docs history — output correctly lists the changed rule, its baseline, and the intervening commit range.

## Note on #51
This branch and the plan-archival PR #51 both edit `generate.yaml`, so expect a small merge conflict in the PR-body block. `sync-report.mjs` references `docs/plans/docs-driven-skills.md` (correct against current `main`); if #51 lands first, that pointer should be updated to `docs/plans-archive/...` in a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)