### PR TITLE
docs: document process-wide tables and reading Harper data during SSR

### DIFF
--- a/harper-best-practices/AGENTS.md
+++ b/harper-best-practices/AGENTS.md
@@ -2194,6 +2194,34 @@ static:
 - Install dependencies: `npm install --save-dev vite @harperfast/vite @vitejs/plugin-react` (swap in your framework's Vite plugin, e.g. `@vitejs/plugin-vue`).
 - Then `harper dev .` runs the app with HMR and `harper run .` runs the production build. Vite does _not_ need to be executed separately.
 
+#### Reading Harper Data During SSR
+
+The render entry (`src/entry-server.tsx`) runs **inside Harper**, so it can read straight from the database and render the data into the HTML — no client-side fetch/XHR. `tables` is the same live, process-wide registry available everywhere (see [Programmatic Table Requests](programmatic-table-requests.md)); import it and query a table in an async `render`:
+
+```tsx
+import { tables } from 'harper';
+
+export async function render(url: string): Promise<string> {
+	const product = await tables.Product.get(idFromUrl(url));
+	return renderToString(
+		<StrictMode>
+			<App product={product} />
+		</StrictMode>,
+	);
+}
+```
+
+Keep `harper` external in `vite.config.ts` so this import resolves to Harper's running runtime instead of being bundled. `node_modules/harper` is symlinked to the running install, and symlinked deps aren't reliably auto-externalized for SSR:
+
+```typescript
+export default defineConfig({
+	ssr: { external: ['harper'] },
+	// ...plugins, resolve, build
+});
+```
+
+To hydrate on the client without re-fetching, embed the rendered data in the HTML (e.g. an inline `<script type="application/json">`) and read it back before hydration — so the page needs no XHR at all.
+
 #### Deploying to Production
 
 Because `@harperfast/vite` builds on the node and `static` serves the output, deploy the component as-is — no manual build-and-move step is needed:

--- a/harper-best-practices/rules/serving-web-content.md
+++ b/harper-best-practices/rules/serving-web-content.md
@@ -68,6 +68,34 @@ static:
 - Install dependencies: `npm install --save-dev vite @harperfast/vite @vitejs/plugin-react` (swap in your framework's Vite plugin, e.g. `@vitejs/plugin-vue`).
 - Then `harper dev .` runs the app with HMR and `harper run .` runs the production build. Vite does _not_ need to be executed separately.
 
+## Reading Harper Data During SSR
+
+The render entry (`src/entry-server.tsx`) runs **inside Harper**, so it can read straight from the database and render the data into the HTML — no client-side fetch/XHR. `tables` is the same live, process-wide registry available everywhere (see [Programmatic Table Requests](programmatic-table-requests.md)); import it and query a table in an async `render`:
+
+```tsx
+import { tables } from 'harper';
+
+export async function render(url: string): Promise<string> {
+	const product = await tables.Product.get(idFromUrl(url));
+	return renderToString(
+		<StrictMode>
+			<App product={product} />
+		</StrictMode>,
+	);
+}
+```
+
+Keep `harper` external in `vite.config.ts` so this import resolves to Harper's running runtime instead of being bundled. `node_modules/harper` is symlinked to the running install, and symlinked deps aren't reliably auto-externalized for SSR:
+
+```typescript
+export default defineConfig({
+	ssr: { external: ['harper'] },
+	// ...plugins, resolve, build
+});
+```
+
+To hydrate on the client without re-fetching, embed the rendered data in the HTML (e.g. an inline `<script type="application/json">`) and read it back before hydration — so the page needs no XHR at all.
+
 ## Deploying to Production
 
 Because `@harperfast/vite` builds on the node and `static` serves the output, deploy the component as-is — no manual build-and-move step is needed:


### PR DESCRIPTION
## Why

Two `harper-best-practices` rules combined to leave readers (and agents) believing a Vite-loaded SSR entry can't reach Harper data — which pushes people toward workarounds like fetching their own REST API over loopback:

- `programmatic-table-requests` scoped table access to *"Harper Resources or scripts"* and called `tables` *"the global"* without noting it's the same instance you can `import { tables } from 'harper'`.
- `serving-web-content` documented the Vite/SSR wiring but never how to **read data** during SSR.

`tables`/`databases` are live, **process-wide** objects available in any module Harper loads — including an SSR entry (whose `node_modules/harper` is symlinked to the running install).

## What

- **`programmatic-table-requests.md`** — clarify `tables`/`databases` are live, process-wide objects available in resources, scripts, **and** an SSR entry; usable as a bare global or via `import { tables } from 'harper'` (same instance). Broadened "When to Use" accordingly.
- **`serving-web-content.md`** — added a **"Reading Harper Data During SSR"** section: query a table in an async `render`, keep `harper` in `ssr.external` (symlinked deps aren't reliably auto-externalized for SSR), and embed the rendered state for XHR-free hydration.
- **`AGENTS.md`** — regenerated from the rules (deterministic assembly from the rule bodies; no docs build or LLM step involved). `validate-generated` passes.

Both edited rules are `mode: synthesized` (hand-maintained), so this is the correct source to edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)