### PR TITLE
chore(intake): add typed issue templates and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Report incorrect, outdated, or broken content in a Harper skill/rule.
+type: Bug
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the Harper skills. Use this for a rule that is **wrong** — incorrect API, outdated syntax, broken example, or guidance that doesn't match Harper v5 behavior. For a new rule or capability, use the Feature request instead.
+  - type: input
+    id: rule
+    attributes:
+      label: Which skill/rule?
+      description: The rule slug or file, e.g. `programmatic-table-requests` or `harper-best-practices/rules/caching.md`.
+      placeholder: defining-relationships
+    validations:
+      required: true
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: What's incorrect?
+      description: Quote the problematic line(s) and explain what's wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected / correct content
+      description: What should the rule say instead? Link the canonical docs if you have them.
+    validations:
+      required: true
+  - type: input
+    id: harper-version
+    attributes:
+      label: Harper version
+      description: The Harper version where you observed this (if relevant).
+      placeholder: '5.1'
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, repro, or the agent behavior that surfaced this.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Harper documentation
+    url: https://docs.harperdb.io/
+    about: Questions about using Harper? Check the documentation first — these issues are for the agent skills/rules themselves.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a new skill/rule or an enhancement to an existing one.
+type: Feature
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to propose a **new** rule/skill or a substantive enhancement to an existing one. For a factual error in an existing rule, use the Bug report instead.
+  - type: textarea
+    id: capability
+    attributes:
+      label: What capability should the skills cover?
+      description: Describe the Harper capability or workflow an agent should be guided through.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: What goes wrong today without it? What does an agent get wrong?
+    validations:
+      required: true
+  - type: input
+    id: docs
+    attributes:
+      label: Canonical docs reference
+      description: Link the Harper v5 docs page(s) this would be sourced from, if they exist. (Rules are ideally generated from canonical docs.)
+      placeholder: https://docs.harperdb.io/...
+    validations:
+      required: false
+  - type: input
+    id: rule-name
+    attributes:
+      label: Proposed rule name (optional)
+      description: A kebab-case slug, e.g. `creating-harper-apps`.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Adds typed issue intake so new reports are categorized at creation (and the stock `bug`/`enhancement` labels stay retired in favor of org issue types).

- **`bug.yml`** — `type: Bug`, scoped to incorrect/outdated rule content (which rule, what's wrong, expected, Harper version).
- **`feature.yml`** — `type: Feature`, for a new rule/skill or enhancement (capability, why, canonical docs reference, proposed slug).
- **`config.yml`** — `blank_issues_enabled: false` + a contact link to the Harper documentation, so usage questions don't land here.

The forms set the org issue **type** directly via the form `type:` field.

> Board auto-add will be handled via the project's built-in "Auto-add to project" workflow rather than a repo workflow file.

## Validation

`npm run validate` passes; all template YAML parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)